### PR TITLE
Fixes 4110: Add support for the Reciprocal rank fusion in the Elastic procedures

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/elasticsearch.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/elasticsearch.adoc
@@ -269,3 +269,138 @@ CALL apoc.es.put($host,'<indexName>', null, null, null, null, { version: 'EIGHT'
 === Results
 
 Results are stream of map in value.
+
+== Reciprocal Rank Fusion (RRF)
+
+RRF can be performed from Neo4j using ES. For further details, read the https://www.elastic.co/guide/en/elasticsearch/reference/current/rrf.html[official documentation].
+
+Here an example using Neo4j with ES.
+
+=== Step 1 - Mapping creation
+
+[source, cypher]
+----
+CALL apoc.es.put($host, 'example-index', null, null, null,
+{
+              "mappings": {
+                "properties": {
+                  "text": {
+                    "type": "text"
+                  },
+                  "vector": {
+                    "type": "dense_vector",
+                    "dims": 1,
+                    "index": true,
+                    "similarity": "l2_norm"
+                  },
+                  "integer": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }, $config)
+----
+
+==== Results
+
+Results are stream of map in value.
+
+=== Step 2 - Put documents
+
+[source, cypher]
+----
+CALL apoc.es.put($host, 'example-index/_doc/1', null, null, null,
+{
+    "text" : "rrf",
+    "vector" : [5],
+    "integer": 1
+}, $config)
+
+CALL apoc.es.put($host, 'example-index/_doc/2', null, null, null,
+{
+    "text" : "rrf rrf",
+    "vector" : [4],
+    "integer": 2
+}, $config)
+
+CALL apoc.es.put($host, 'example-index/_doc/3', null, null, null,
+{
+    "text" : "rrf rrf rrf",
+    "vector" : [3],
+    "integer": 1
+}, $config)
+
+CALL apoc.es.put($host, 'example-index/_doc/4', null, null, null,
+{
+    "text" : "rrf rrf rrf rrf",
+    "integer": 2
+}, $config)
+
+CALL apoc.es.put($host, 'example-index/_doc/5', null, null, null,
+{
+    "vector" : [0],
+    "integer": 1
+}, $config)
+----
+
+==== Results
+
+Results are stream of map in value.
+
+=== Step 3 - Refresh index
+
+[source, cypher]
+----
+CALL apoc.es.post($host, 'example-index/_refresh', null, null, '', $config)
+----
+
+==== Results
+
+Results are stream of map in value.
+
+=== Step 4 - Perform search using rrf retriever
+
+[source, cypher]
+----
+CALL apoc.es.getRaw($host,'example-index/_search',
+{
+    "retriever": {
+        "rrf": {
+            "retrievers": [
+                {
+                    "standard": {
+                        "query": {
+                            "term": {
+                                "text": "rrf"
+                            }
+                        }
+                    }
+                },
+                {
+                    "knn": {
+                        "field": "vector",
+                        "query_vector": [3],
+                        "k": 5,
+                        "num_candidates": 5
+                    }
+                }
+            ],
+            "window_size": 5,
+            "rank_constant": 1
+        }
+    },
+    "size": 3,
+    "aggs": {
+        "int_count": {
+            "terms": {
+                "field": "integer"
+            }
+        }
+    }
+}
+,$config) yield value
+----
+
+==== Results
+
+Results are stream of map in value.

--- a/docs/asciidoc/modules/ROOT/pages/overview/apoc.es/apoc.es.post.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/apoc.es/apoc.es.post.adoc
@@ -14,7 +14,7 @@ apoc.es.post(host-or-key,index-or-null,type-or-null,query-or-null,payload-or-nul
 
 [source]
 ----
-apoc.es.post(host :: STRING?, index :: STRING?, type :: STRING?, query :: ANY?, payload = {} :: MAP?, config = {} :: MAP?) :: (value :: MAP?)
+apoc.es.post(host :: STRING?, index :: STRING?, type :: STRING?, query :: ANY?, payload = {} :: ANY?, config = {} :: MAP?) :: (value :: MAP?)
 ----
 
 == Input parameters

--- a/extended-it/src/test/java/apoc/es/ElasticVersionEightTest.java
+++ b/extended-it/src/test/java/apoc/es/ElasticVersionEightTest.java
@@ -1,7 +1,10 @@
 package apoc.es;
 
+import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.nimbusds.jose.util.Pair;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -22,10 +25,11 @@ public class ElasticVersionEightTest extends ElasticSearchTest {
         Map<String, Object> params = Util.map("index", ES_INDEX,
                 "id", ES_ID, "type", ES_TYPE, "config", config);
         
-        String tag = "8.12.1";
+        String tag = "8.14.3";
         Map<String, String> envMap = Map.of(
                 "xpack.security.http.ssl.enabled", "false",
-                "cluster.routing.allocation.disk.threshold_enabled","false"
+                "cluster.routing.allocation.disk.threshold_enabled","false",
+                "xpack.license.self_generated.type", "trial" // To avoid error "current license is non-compliant for [Reciprocal Rank Fusion (RRF)]"
         );
 
         getElasticContainer(tag, envMap, params);
@@ -66,6 +70,135 @@ public class ElasticVersionEightTest extends ElasticSearchTest {
     public void testSearchWithQueryAsPayloadAndWithoutIndex() {
         TestUtil.testCall(db, "CALL apoc.es.query($host, null, null, 'pretty', {`_source`: {includes: ['name']}}, $config) yield value", paramsWithBasicAuth,
                 this::searchQueryPayloadAssertions);
+    }
+
+    @Test
+    public void testSearchRRF() throws JsonProcessingException {
+        String payload = """
+            {
+              "mappings": {
+                "properties": {
+                  "text": {
+                    "type": "text"
+                  },
+                  "vector": {
+                    "type": "dense_vector",
+                    "dims": 1,
+                    "index": true,
+                    "similarity": "l2_norm"
+                  },
+                  "integer": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+            """;
+
+        setPayload(payload, paramsWithBasicAuth);
+        TestUtil.testCall(db, "CALL apoc.es.put($host, 'example-index', null, null, null, $payload, $config)",
+                paramsWithBasicAuth,
+                r -> {
+                    Object actual = ((Map) r.get("value")).get("index");
+                    assertEquals("example-index", actual);
+                });
+
+        assertPutForRRF();
+
+        paramsWithBasicAuth.remove("payload");
+        TestUtil.testCall(db, "CALL apoc.es.post($host, 'example-index/_refresh', null, null, '', $config)",
+                paramsWithBasicAuth,
+                r -> {
+                    Object actual = ((Map) ((Map) r.get("value")).get("_shards")).get("successful");
+                    assertEquals(1L, actual);
+                });
+
+        payload = """
+             {
+                 "retriever": {
+                     "rrf": {
+                         "retrievers": [
+                             {
+                                 "standard": {
+                                     "query": {
+                                         "term": {
+                                             "text": "rrf"
+                                         }
+                                     }
+                                 }
+                             },
+                             {
+                                 "knn": {
+                                     "field": "vector",
+                                     "query_vector": [3],
+                                     "k": 5,
+                                     "num_candidates": 5
+                                 }
+                             }
+                         ],
+                         "window_size": 5,
+                         "rank_constant": 1
+                     }
+                 },
+                 "size": 3,
+                 "aggs": {
+                     "int_count": {
+                         "terms": {
+                             "field": "integer"
+                         }
+                     }
+                 }
+             }
+                """;
+
+        setPayload(payload, paramsWithBasicAuth);
+        TestUtil.testCall(db, "CALL apoc.es.getRaw($host,'example-index/_search',$payload,$config) yield value",
+                paramsWithBasicAuth,
+                r -> {
+                    Object result = ((Map) ((Map) ((Map) r.get("value")).get("hits")).get("total")).get("value");
+                    assertEquals(5L, result);
+                });
+
+        TestUtil.testCall(db, "CALL apoc.es.delete($host,'example-index',null,null,null,$config)",
+                paramsWithBasicAuth,
+                r -> {
+                    boolean acknowledged = ((boolean) ((Map) r.get("value")).get("acknowledged"));
+                    assertTrue(acknowledged);
+                });
+
+        paramsWithBasicAuth.put("index", ES_INDEX);
+    }
+
+    private void assertPutForRRF() {
+        List<Pair<String, String>> payloads = List.of(
+                Pair.of("example-index/_doc/1", "{ \"text\" : \"rrf\", \"vector\" : [5], \"integer\": 1 }"),
+                Pair.of("example-index/_doc/2", "{ \"text\" : \"rrf rrf\", \"vector\" : [4], \"integer\": 2 }"),
+                Pair.of("example-index/_doc/3", "{ \"text\" : \"rrf rrf rrf\", \"vector\" : [3], \"integer\": 1 }"),
+                Pair.of("example-index/_doc/4", "{ \"text\" : \"rrf rrf rrf rrf\", \"integer\": 2 }"),
+                Pair.of("example-index/_doc/5", "{ \"vector\" : [0], \"integer\": 1 }")
+        );
+
+        payloads.forEach(payload -> {
+            try {
+                Map mapPayload = JsonUtil.OBJECT_MAPPER.readValue(payload.getRight(), Map.class);
+                paramsWithBasicAuth.put("payload", mapPayload);
+                paramsWithBasicAuth.put("index", payload.getLeft());
+                TestUtil.testCall(db, "CALL apoc.es.put($host, $index, null, null, null, $payload, $config)",
+                        paramsWithBasicAuth,
+                        r -> {
+                            Object actual = ((Map) r.get("value")).get("result");
+                            assertEquals("created", actual);
+                        });
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+    }
+
+    private void setPayload(String payload, Map<String, Object> params) throws JsonProcessingException {
+        Map<String, Object> mapPayload = JsonUtil.OBJECT_MAPPER.readValue(payload, Map.class);
+        params.put("payload", mapPayload);
     }
 
     private void searchQueryPayloadAssertions(Map<String, Object> r) {

--- a/extended/src/main/java/apoc/es/ElasticSearch.java
+++ b/extended/src/main/java/apoc/es/ElasticSearch.java
@@ -81,7 +81,7 @@ public class ElasticSearch {
     @Procedure
     @Description("apoc.es.post(host-or-key,index-or-null,type-or-null,query-or-null,payload-or-null,$config) yield value - perform a POST operation on elastic search")
     public Stream<MapResult> post(@Name("hostOrKey") String hostOrKey, @Name("index") String index, @Name("type") String type, @Name("query") Object query,
-                                  @Name(value = "payload", defaultValue = "{}") Map<String,Object> payload,
+                                  @Name(value = "payload", defaultValue = "{}") Object payload,
                                   @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         if (payload == null)
         {


### PR DESCRIPTION
- Updated ElasticSearch container version to 8.14.3 to support Reciprocal Rank Fusion (RRF)
- Changed license version to `trial` to use RRF search
- Changed input type from Map to Object to procedure `apoc.es.post` to support empty string input for **payload** because passing null produces an empty map `{}`