### PR TITLE
Fixes 4145: Add support for huggingface models

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -267,6 +267,25 @@ Or via https://localai.io/[LocalAI APIs] (note that the apiKey is `null` by defa
 CALL apoc.ml.openai.embedding(['Some Text'], "ignored", 
 {endpoint: 'http://localhost:8080/v1', model: 'text-embedding-ada-002'})
 ----
+We can use https://huggingface.co/tomasonjo[tomasonjo models] to generate Cypher from text:
+
+[source,cypher]
+----
+WITH 'Node properties are the following:
+Movie {title: STRING, votes: INTEGER, tagline: STRING, released: INTEGER}, Person {born: INTEGER, name: STRING}
+Relationship properties are the following:
+ACTED_IN {roles: LIST}, REVIEWED {summary: STRING, rating: INTEGER}
+The relationships are the following:
+(:Person)-[:ACTED_IN]->(:Movie), (:Person)-[:DIRECTED]->(:Movie), (:Person)-[:PRODUCED]->(:Movie), (:Person)-[:WROTE]->(:Movie), (:Person)-[:FOLLOWS]->(:Person), (:Person)-[:REVIEWED]->(:Movie)'
+as schema,
+'Which actors played in the most movies?' as question
+CALL apoc.ml.openai.chat([
+            {role:"system", content:"Given an input question, convert it to a Cypher query. No pre-amble."},
+            {role:"user", content:"Based on the Neo4j graph schema below, write a Cypher query that would answer the user's question:
+\n "+ schema +" \n\n Question: "+ question +" \n Cypher query:"}
+            ], '<apiKey>', { endpoint: 'http://localhost:8080/chat/completions', model: 'text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf'})
+YIELD value RETURN value
+----
 
 Or also, by using https://github.com/fardjad/node-llmatic[LLMatic Library]:
 [source,cypher]

--- a/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
@@ -78,11 +78,16 @@ public class OpenAILocalAIIT {
 
     @Test
     public void chatCompletionTomasonjo() {
-        // Terminal commands
-        // ./local-ai run https://huggingface.co/tomasonjo/text2cypher-demo-4bit-gguf/resolve/main/text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf
-        // ./local-ai run https://huggingface.co/tomasonjo/text2cypher-codestral-q4_k_m-gguf/resolve/main/text2cypher-codestral-q4_k_m-gguf-unsloth.Q4_K_M.gguf
-        // curl http://localhost:8080/v1/models // List models
-        // curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf", "messages": [{"role": "user", "content": "What is the color of the sky? Answer in one word"}] }'
+        /*
+        Useful terminal commands:
+        # Run models
+        ./local-ai run https://huggingface.co/tomasonjo/text2cypher-demo-4bit-gguf/resolve/main/text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf // List models
+        ./local-ai run https://huggingface.co/tomasonjo/text2cypher-codestral-q4_k_m-gguf/resolve/main/text2cypher-codestral-q4_k_m-gguf-unsloth.Q4_K_M.gguf
+        # List Models
+        curl http://localhost:8080/v1/models
+        # Call model
+        curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf", "messages": [{"role": "user", "content": "What is the color of the sky? Answer in one word"}] }'
+        */
         String[] models = {
                 "text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf",
                 "text2cypher-demo-8bit-gguf-unsloth.Q8_0.gguf",
@@ -109,8 +114,16 @@ public class OpenAILocalAIIT {
 
         String question = "Which actors played in the most movies?";
         String model = "text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf";
+
+        Map<String, Object> params = Util.map(
+                "schema", schema,
+                "question", question
+        );
+
+        params.putAll(getParams(model));
+
         testCall(db, TEXT_TO_CYPHER_QUERY,
-                getParams(model, schema, question),
+                params,
                 row -> {
                     String cypherResult = assertChatCompletion(row, model);
                     // Check that is valid query
@@ -137,18 +150,6 @@ public class OpenAILocalAIIT {
         return Util.map("apiKey", "x",
                 "conf", Map.of(ENDPOINT_CONF_KEY, localAIUrl,
                         MODEL_CONF_KEY, model)
-        );
-    }
-
-    private Map<String, Object> getParams(String model, String schema, String question) {
-        return Util.map(
-                "apiKey", "x",
-                "conf", Map.of(
-                        ENDPOINT_CONF_KEY, localAIUrl,
-                        MODEL_CONF_KEY, model
-                ),
-                "schema", schema,
-                "question", question
         );
     }
 }

--- a/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
@@ -1,11 +1,15 @@
 package apoc.ml;
 
+import apoc.coll.Coll;
+import apoc.meta.Meta;
+import apoc.text.Strings;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -13,29 +17,51 @@ import java.util.List;
 import java.util.Map;
 
 import static apoc.ml.MLUtil.*;
-import static apoc.ml.OpenAITestResultUtils.*;
+import static apoc.ml.OpenAITestResultUtils.CHAT_COMPLETION_QUERY;
+import static apoc.ml.OpenAITestResultUtils.COMPLETION_QUERY;
+import static apoc.ml.OpenAITestResultUtils.EMBEDDING_QUERY;
+import static apoc.ml.OpenAITestResultUtils.TEXT_TO_CYPHER_QUERY;
+import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
+import static apoc.ml.OpenAITestResultUtils.assertCompletion;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
  * To start the tests, follow the instructions provided here: https://localai.io/basics/build/
  * Then, download the embedding model, as explained here: https://localai.io/models/#embeddings-bert 
  * Finally, set the env var `LOCAL_AI_URL=http://localhost:<portNumber>/v1`, default is `LOCAL_AI_URL=http://localhost:8080/v1`
+ *
+ * To test chatCompletionTomasonjo/text2CypherTomasonjo4Bit run localai with the command below:
+ * ./local-ai run https://huggingface.co/tomasonjo/text2cypher-demo-4bit-gguf/resolve/main/text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf
  */
 public class OpenAILocalAIIT {
 
     private String localAIUrl;
+    private static final String OPENAI_KEY = System.getenv("OPENAI_KEY");
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
-
 
     @Before
     public void setUp() throws Exception {
         localAIUrl = System.getenv("LOCAL_AI_URL");
         Assume.assumeNotNull("No LOCAL_AI_URL environment configured", localAIUrl);
-        TestUtil.registerProcedure(db, OpenAI.class);
+        TestUtil.registerProcedure(db, OpenAI.class, Prompt.class, Meta.class, Strings.class, Coll.class);
+
+        String movies = Util.readResourceFile("movies.cypher");
+        try (Transaction tx = db.beginTx()) {
+            tx.execute(movies);
+            tx.commit();
+        }
+
+        String rag = Util.readResourceFile("rag.cypher");
+        try (Transaction tx = db.beginTx()) {
+            tx.execute(rag);
+            tx.commit();
+        }
     }
 
     @Test
@@ -47,6 +73,49 @@ public class OpenAILocalAIIT {
                     assertEquals("Some Text", row.get("text"));
                     var embedding = (List<Double>) row.get("embedding");
                     assertEquals(384, embedding.size());
+                });
+    }
+
+    @Test
+    public void chatCompletionTomasonjo() {
+        // Terminal commands
+        // ./local-ai run https://huggingface.co/tomasonjo/text2cypher-demo-4bit-gguf/resolve/main/text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf
+        // ./local-ai run https://huggingface.co/tomasonjo/text2cypher-codestral-q4_k_m-gguf/resolve/main/text2cypher-codestral-q4_k_m-gguf-unsloth.Q4_K_M.gguf
+        // curl http://localhost:8080/v1/models // List models
+        // curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf", "messages": [{"role": "user", "content": "What is the color of the sky? Answer in one word"}] }'
+        String[] models = {
+                "text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf",
+                "text2cypher-demo-8bit-gguf-unsloth.Q8_0.gguf",
+        };
+
+        for (String model : models) {
+            testCall(db, CHAT_COMPLETION_QUERY,
+                    getParams(model),
+                    row -> assertChatCompletion(row, model));
+        }
+    }
+
+    @Test
+    public void text2CypherTomasonjo4Bit() {
+        assertNotNull(OPENAI_KEY);
+        String schema = """
+                Node properties are the following:
+                Movie {title: STRING, votes: INTEGER, tagline: STRING, released: INTEGER}, Person {born: INTEGER, name: STRING}
+                Relationship properties are the following:
+                ACTED_IN {roles: LIST}, REVIEWED {summary: STRING, rating: INTEGER}
+                The relationships are the following:
+                (:Person)-[:ACTED_IN]->(:Movie), (:Person)-[:DIRECTED]->(:Movie), (:Person)-[:PRODUCED]->(:Movie), (:Person)-[:WROTE]->(:Movie), (:Person)-[:FOLLOWS]->(:Person), (:Person)-[:REVIEWED]->(:Movie)
+                """;
+
+        String question = "Which actors played in the most movies?";
+        String model = "text2cypher-demo-4bit-gguf-unsloth.Q4_K_M.gguf";
+        testCall(db, TEXT_TO_CYPHER_QUERY,
+                getParams(model, schema, question),
+                row -> {
+                    String cypherResult = assertChatCompletion(row, model);
+                    // Check that is valid query
+                    long count = TestUtil.count(db, cypherResult);
+                    assertTrue(count > 0);
                 });
     }
 
@@ -68,6 +137,18 @@ public class OpenAILocalAIIT {
         return Util.map("apiKey", "x",
                 "conf", Map.of(ENDPOINT_CONF_KEY, localAIUrl,
                         MODEL_CONF_KEY, model)
+        );
+    }
+
+    private Map<String, Object> getParams(String model, String schema, String question) {
+        return Util.map(
+                "apiKey", "x",
+                "conf", Map.of(
+                        ENDPOINT_CONF_KEY, localAIUrl,
+                        MODEL_CONF_KEY, model
+                ),
+                "schema", schema,
+                "question", question
         );
     }
 }


### PR DESCRIPTION
Test [tomasonjo](https://huggingface.co/tomasonjo) models for text2cypher with LocalAI

We have to deploy the model (with LocalAI in this case), as we cannot use the public remote [HF Inference API](https://huggingface.co/docs/api-inference/index), see `https://github.com/huggingface/chat-ui/issues/230`, 
for example:
```
$ curl https://api-inference.huggingface.co/models/tomasonjo/text2cypher-codestral-16bit \
        -d '{"inputs": "What color is the sky?"}' \
        -H 'Content-Type: application/json' \
        -H "Authorization: Bearer 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"

{"error":"The model tomasonjo/text2cypher-codestral-16bit is too large to be loaded automatically (44GB > 10GB). Please use Spaces (https://huggingface.co/spaces) or Inference Endpoints (https://huggingface.co/inference-endpoints)."}%   


$ curl https://api-inference.huggingface.co/models/tomasonjo/text2cypher-demo-6bit-gguf \
        -d '{"inputs": [{"role":"user", "content":"Retrieve distinct values of the title and the comments from Article where title is not The Gervais-Neveu-Felder"}]}' \
        -H 'Content-Type: application/json' \
        -H "Authorization: Bearer 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"

{"error":"Task not found for this model"}
```
