### PR TITLE
Fixes 4232: The apoc.vectordb.configure(WEAVIATE', ..) procedure should append /v1 to url

### DIFF
--- a/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
@@ -4,7 +4,6 @@ import apoc.ml.Prompt;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import org.junit.AfterClass;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -494,6 +493,49 @@ public class WeaviateTest {
     public void queryVectorsWithSystemDbStorage() {
         String keyConfig = "weaviate-config-foo";
         String baseUrl = "http://" + HOST + "/v1";
+        assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl);
+    }
+
+    @Test
+    public void queryVectorsWithSystemDbStorageWithUrlWithoutVersion() {
+        String keyConfig = "weaviate-config-foo";
+        String baseUrl = "http://" + HOST;
+        assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl);
+    }
+
+    @Test
+    public void queryVectorsWithRag() {
+        String openAIKey = ragSetup(db);
+
+        Map<String, Object> conf = MapUtil.map(
+                FIELDS_KEY, FIELDS,
+                ALL_RESULTS_KEY, true,
+                HEADERS_KEY, READONLY_AUTHORIZATION,
+                MAPPING_KEY, MapUtil.map(EMBEDDING_KEY, "vect",
+                        NODE_LABEL, "Rag",
+                        ENTITY_KEY, "readID",
+                        METADATA_KEY, "foo")
+        );
+
+        testResult(db,
+                """
+                    CALL apoc.vectordb.weaviate.getAndUpdate($host, 'TestCollection', [$id1], $conf) YIELD score, node, metadata, id, vector
+                    WITH collect(node) as paths
+                    CALL apoc.ml.rag(paths, $attributes, "Which city has foo equals to one?", $confPrompt) YIELD value
+                    RETURN value
+                    """
+                ,
+                MapUtil.map(
+                        "host", HOST,
+                        "id1", ID_1,
+                        "conf", conf,
+                        "confPrompt", MapUtil.map(API_KEY_CONF, openAIKey),
+                        "attributes", List.of("city", "foo")
+                ),
+                VectorDbTestUtil::assertRagWithVectors);
+    }
+
+    private static void assertQueryVectorsWithSystemDbStorage(String keyConfig, String baseUrl) {
         Map<String, String> mapping = map(EMBEDDING_KEY, "vect",
                 NODE_LABEL, "Test",
                 ENTITY_KEY, "myId",
@@ -529,37 +571,5 @@ public class WeaviateTest {
                 });
 
         assertNodesCreated(db);
-    }
-
-    @Test
-    public void queryVectorsWithRag() {
-        String openAIKey = ragSetup(db);
-
-        Map<String, Object> conf = MapUtil.map(
-                FIELDS_KEY, FIELDS,
-                ALL_RESULTS_KEY, true,
-                HEADERS_KEY, READONLY_AUTHORIZATION,
-                MAPPING_KEY, MapUtil.map(EMBEDDING_KEY, "vect",
-                        NODE_LABEL, "Rag",
-                        ENTITY_KEY, "readID",
-                        METADATA_KEY, "foo")
-        );
-
-        testResult(db,
-                """
-                    CALL apoc.vectordb.weaviate.getAndUpdate($host, 'TestCollection', [$id1], $conf) YIELD score, node, metadata, id, vector
-                    WITH collect(node) as paths
-                    CALL apoc.ml.rag(paths, $attributes, "Which city has foo equals to one?", $confPrompt) YIELD value
-                    RETURN value
-                    """
-                ,
-                MapUtil.map(
-                        "host", HOST,
-                        "id1", ID_1,
-                        "conf", conf,
-                        "confPrompt", MapUtil.map(API_KEY_CONF, openAIKey),
-                        "attributes", List.of("city", "foo")
-                ),
-                VectorDbTestUtil::assertRagWithVectors);
     }
 }

--- a/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
@@ -493,14 +493,21 @@ public class WeaviateTest {
     public void queryVectorsWithSystemDbStorage() {
         String keyConfig = "weaviate-config-foo";
         String baseUrl = "http://" + HOST + "/v1";
-        assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl);
+        assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl, false);
     }
 
     @Test
     public void queryVectorsWithSystemDbStorageWithUrlWithoutVersion() {
         String keyConfig = "weaviate-config-foo";
         String baseUrl = "http://" + HOST;
-        assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl);
+        assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl, false);
+    }
+
+    @Test
+    public void queryVectorsWithSystemDbStorageWithUrlV3Version() {
+        String keyConfig = "weaviate-config-foo";
+        String baseUrl = "http://" + HOST + "/v3";
+        assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl, true);
     }
 
     @Test
@@ -535,7 +542,7 @@ public class WeaviateTest {
                 VectorDbTestUtil::assertRagWithVectors);
     }
 
-    private static void assertQueryVectorsWithSystemDbStorage(String keyConfig, String baseUrl) {
+    private static void assertQueryVectorsWithSystemDbStorage(String keyConfig, String baseUrl, boolean fails) {
         Map<String, String> mapping = map(EMBEDDING_KEY, "vect",
                 NODE_LABEL, "Test",
                 ENTITY_KEY, "myId",
@@ -554,10 +561,24 @@ public class WeaviateTest {
 
         db.executeTransactionally("CREATE (:Test {myId: 'one'}), (:Test {myId: 'two'})");
 
-        testResult(db, "CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf)",
-                map("host", keyConfig,
-                        "conf", map(FIELDS_KEY, FIELDS, ALL_RESULTS_KEY, true)
-                ),
+        String query = "CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf)";
+        Map<String, Object> params = map("host", keyConfig,
+                "conf", map(FIELDS_KEY, FIELDS, ALL_RESULTS_KEY, true)
+        );
+
+        if (fails) {
+            assertFails(
+                    db,
+                    query,
+                    params,
+                    "Caused by: java.io.FileNotFoundException: http://127.0.0.1:" +  HOST.split(":")[1] + "/v3/graphql"
+            );
+            return;
+        }
+
+
+        testResult(db, query,
+                params,
                 r -> {
                     Map<String, Object> row = r.next();
                     assertBerlinResult(row, ID_1, NODE);

--- a/extended/src/main/java/apoc/vectordb/VectorDb.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDb.java
@@ -38,7 +38,9 @@ import static apoc.util.ExtendedUtil.listOfNumbersToFloatArray;
 import static apoc.util.ExtendedUtil.setProperties;
 import static apoc.util.JsonUtil.OBJECT_MAPPER;
 import static apoc.util.SystemDbUtil.withSystemDb;
-import static apoc.vectordb.VectorDbUtil.*;
+import static apoc.vectordb.VectorDbUtil.EmbeddingResult;
+import static apoc.vectordb.VectorDbUtil.appendVersionUrlIfNeeded;
+import static apoc.vectordb.VectorDbUtil.getEndpoint;
 import static apoc.vectordb.VectorEmbeddingConfig.ALL_RESULTS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.MAPPING_KEY;
 
@@ -259,7 +261,7 @@ public class VectorDb {
             Node node = Util.mergeNode(transaction, label, null, Pair.of(SystemPropertyKeys.name.name(), configKey));
 
             Map mapping = (Map) config.get("mapping");
-            String host = (String) config.get("host");
+            String host = appendVersionUrlIfNeeded(type, (String) config.get("host"));
             Object credentials = config.get("credentials");
 
             if (host != null) {

--- a/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
@@ -131,6 +131,10 @@ public class VectorDbUtil {
         config.put(BODY_KEY, null);
     }
 
+    /**
+     * If the vectorDb is WEAVIATE and endpoint doesn't end with `/vN`, where N is a number,
+     * then add `/v1` to the endpoint
+     */
     public static String appendVersionUrlIfNeeded(VectorDbHandler.Type type, String host) {
         if (VectorDbHandler.Type.WEAVIATE == type) {
             String regex = ".*(/v\\d+)$";

--- a/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
@@ -130,4 +130,14 @@ public class VectorDbUtil {
         config.put(METHOD_KEY, null);
         config.put(BODY_KEY, null);
     }
+
+    public static String appendVersionUrlIfNeeded(VectorDbHandler.Type type, String host) {
+        if (VectorDbHandler.Type.WEAVIATE == type) {
+            String regex = ".*(/v\\d+)$";
+            if (!host.matches(regex)) {
+                host = host + "/v1";
+            }
+        }
+        return host;
+    }
 }


### PR DESCRIPTION
Aggiunto metodo `appendVersionUrlIfNeeded` in VectorDbUtil usato in `apoc.vectordb.configure`
Se l'host non termina per /vNUMERO aggiungo /v1
