### PR TITLE
Fixes 4242: The Pinecone APOC implementation is misleading

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/pinecone.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/pinecone.adoc
@@ -1,24 +1,32 @@
 
 = Pinecone
 
+[NOTE]
+====
+The procedures create/drop/handle an index, instead of a collection like the other vectordb procedures,
+since in Pinecone a collection is a static and non-queryable copy of an index.
+
+Anyway, the create / delete index procedures are named `.createCollection` and `.deleteCollection` to be consistent with the other.
+====
+
 Here is a list of all available Pinecone procedures:
 
 [opts=header, cols="1, 3"]
 |===
 | name | description
-| apoc.vectordb.pinecone.info(hostOrKey, collection, $config) | Get information about the specified existing collection or throws a 404 error if it does not exist
+| apoc.vectordb.pinecone.info(hostOrKey, index, $config) | Get information about the specified existing index or throws a 404 error if it does not exist
 | apoc.vectordb.pinecone.createCollection(hostOrKey, index, similarity, size, $config) |
     Creates an index, with the name specified in the 2nd parameter, and with the specified `similarity` and `size`.
     The default endpoint is `<hostOrKey param>/indexes`.
 | apoc.vectordb.pinecone.deleteCollection(hostOrKey, index, $config) | 
     Deletes an index with the name specified in the 2nd parameter.
-    The default endpoint is `<hostOrKey param>/indexes/<collection param>`.
+    The default endpoint is `<hostOrKey param>/indexes/<index param>`.
 | apoc.vectordb.pinecone.upsert(hostOrKey, index, vectors, $config) | 
     Upserts, in the index with the name specified in the 2nd parameter, the vectors [{id: 'id', vector: '<vectorDb>', medatada: '<metadata>'}].
     The default endpoint is `<hostOrKey param>/vectors/upsert`.
 | apoc.vectordb.pinecone.delete(hostOrKey, index, ids, $config) | 
     Delete the vectors with the specified `ids`.
-    The default endpoint is `<hostOrKey param>/indexes/<collection param>`.
+    The default endpoint is `<hostOrKey param>/indexes/<index param>`.
 | apoc.vectordb.pinecone.get(hostOrKey, index, ids, $config) | 
     Get the vectors with the specified `ids`.
     The default endpoint is `<hostOrKey param>/vectors/fetch`.
@@ -35,15 +43,6 @@ Here is a list of all available Pinecone procedures:
 
 where the 1st parameter can be a key defined by the apoc config `apoc.pinecone.<key>.host=myHost`.
 
-[NOTE]
-====
-The procedures create/drop/handle an index, instead of a collection like the other vectordb procedures, 
-since in Pinecone a collection is a static and non-queryable copy of an index.
-
-Anyway, the create / delete index procedures are named `.createCollection` and `.deleteCollection` to be consistent with the other.
-====
-
-
 The default `hostOrKey` is `"https://api.pinecone.io"`,
 therefore in general can be null with the `createCollection` and `deleteCollection` procedures,
 and equal to the host name, with the other ones, that is, the one indicated in the Pinecone dashboard:
@@ -55,10 +54,10 @@ image::pinecone-index.png[width=800]
 
 The following example assume we want to create and manage an index called `test-index`.
 
-.Get collection info (it leverages https://docs.pinecone.io/reference/api/control-plane/describe_collection[this API])
+.Get index info (it leverages https://docs.pinecone.io/guides/indexes/view-index-information[this API])
 [source,cypher]
 ----
-CALL apoc.vectordb.pinecone.info(hostOrKey, 'test-collection', {<optional config>})
+CALL apoc.vectordb.pinecone.info(hostOrKey, 'test-index', {<optional config>})
 ----
 
 .Example results
@@ -67,7 +66,7 @@ CALL apoc.vectordb.pinecone.info(hostOrKey, 'test-collection', {<optional config
 | value
 | { "dimension": 3,
     "environment": "us-east1-gcp",
-    "name": "tiny-collection",
+    "name": "tiny-index",
     "size": 3126700,
     "status": "Ready",
     "vector_count": 99
@@ -262,7 +261,7 @@ It is possible to execute vector db procedures together with the xref::ml/rag.ad
 
 [source,cypher]
 ----
-CALL apoc.vectordb.pinecone.getAndUpdate($host, $collection, [<id1>, <id2>], $conf) YIELD node, metadata, id, vector
+CALL apoc.vectordb.pinecone.getAndUpdate($host, $index, [<id1>, <id2>], $conf) YIELD node, metadata, id, vector
 WITH collect(node) as paths
 CALL apoc.ml.rag(paths, $attributes, $question, $confPrompt) YIELD value
 RETURN value

--- a/extended/src/main/java/apoc/vectordb/Pinecone.java
+++ b/extended/src/main/java/apoc/vectordb/Pinecone.java
@@ -43,12 +43,12 @@ public class Pinecone {
     public URLAccessChecker urlAccessChecker;
 
     @Procedure("apoc.vectordb.pinecone.info")
-    @Description("apoc.vectordb.pinecone.info(hostOrKey, collection, $configuration) - Get information about the specified existing collection or throws an error if it does not exist")
+    @Description("apoc.vectordb.pinecone.info(hostOrKey, index, $configuration) - Get information about the specified existing index or throws an error if it does not exist")
     public Stream<MapResult> getInfo(@Name("hostOrKey") String hostOrKey,
-                                              @Name("collection") String collection,
+                                              @Name("index") String index,
                                               @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
         String url = "%s/indexes/%s";
-        Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
+        Map<String, Object> config = getVectorDbInfo(hostOrKey, index, configuration, url);
 
         methodAndPayloadNull(config);
 
@@ -59,18 +59,18 @@ public class Pinecone {
     }
 
     @Procedure("apoc.vectordb.pinecone.createCollection")
-    @Description("apoc.vectordb.pinecone.createCollection(hostOrKey, collection, similarity, size, $configuration) - Creates a collection, with the name specified in the 2nd parameter, and with the specified `similarity` and `size`")
+    @Description("apoc.vectordb.pinecone.createCollection(hostOrKey, index, similarity, size, $configuration) - Creates a index, with the name specified in the 2nd parameter, and with the specified `similarity` and `size`")
     public Stream<MapResult> createCollection(@Name("hostOrKey") String hostOrKey,
-                                              @Name("collection") String collection,
+                                              @Name("index") String index,
                                               @Name("similarity") String similarity,
                                               @Name("size") Long size,
                                               @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
         String url = "%s/indexes";
-        Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
+        Map<String, Object> config = getVectorDbInfo(hostOrKey, index, configuration, url);
         config.putIfAbsent(METHOD_KEY, "POST");
 
         Map<String, Object> additionalBodies = Map.of(
-                "name", collection,
+                "name", index,
                 "dimension", size,
                 "metric", similarity
         );
@@ -81,14 +81,14 @@ public class Pinecone {
     }
 
     @Procedure("apoc.vectordb.pinecone.deleteCollection")
-    @Description("apoc.vectordb.pinecone.deleteCollection(hostOrKey, collection, $configuration) - Deletes a collection with the name specified in the 2nd parameter")
+    @Description("apoc.vectordb.pinecone.deleteCollection(hostOrKey, index, $configuration) - Deletes a index with the name specified in the 2nd parameter")
     public Stream<MapResult> deleteCollection(
             @Name("hostOrKey") String hostOrKey,
-            @Name("collection") String collection,
+            @Name("index") String index,
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
 
         String url = "%s/indexes/%s";
-        Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
+        Map<String, Object> config = getVectorDbInfo(hostOrKey, index, configuration, url);
         config.putIfAbsent(METHOD_KEY, "DELETE");
 
         RestAPIConfig restAPIConfig = new RestAPIConfig(config);
@@ -98,16 +98,16 @@ public class Pinecone {
     }
 
     @Procedure("apoc.vectordb.pinecone.upsert")
-    @Description("apoc.vectordb.pinecone.upsert(hostOrKey, collection, vectors, $configuration) - Upserts, in the collection with the name specified in the 2nd parameter, the vectors [{id: 'id', vector: '<vectorDb>', medatada: '<metadata>'}]")
+    @Description("apoc.vectordb.pinecone.upsert(hostOrKey, index, vectors, $configuration) - Upserts, in the index with the name specified in the 2nd parameter, the vectors [{id: 'id', vector: '<vectorDb>', medatada: '<metadata>'}]")
     public Stream<MapResult> upsert(
             @Name("hostOrKey") String hostOrKey,
-            @Name("collection") String collection,
+            @Name("index") String index,
             @Name("vectors") List<Map<String, Object>> vectors,
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
 
         String url = "%s/vectors/upsert";
 
-        Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
+        Map<String, Object> config = getVectorDbInfo(hostOrKey, index, configuration, url);
         config.putIfAbsent(METHOD_KEY, "POST");
 
         vectors = vectors.stream()
@@ -126,15 +126,15 @@ public class Pinecone {
     }
 
     @Procedure("apoc.vectordb.pinecone.delete")
-    @Description("apoc.vectordb.pinecone.delete(hostOrKey, collection, ids, $configuration) - Delete the vectors with the specified `ids`")
+    @Description("apoc.vectordb.pinecone.delete(hostOrKey, index, ids, $configuration) - Delete the vectors with the specified `ids`")
     public Stream<MapResult> delete(
             @Name("hostOrKey") String hostOrKey,
-            @Name("collection") String collection,
+            @Name("index") String index,
             @Name("vectors") List<Object> ids,
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
 
         String url = "%s/vectors/delete";
-        Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
+        Map<String, Object> config = getVectorDbInfo(hostOrKey, index, configuration, url);
         config.putIfAbsent(METHOD_KEY, "POST");
 
         Map<String, Object> additionalBodies = Map.of("ids", ids);
@@ -145,29 +145,29 @@ public class Pinecone {
     }
 
     @Procedure(value = "apoc.vectordb.pinecone.get")
-    @Description("apoc.vectordb.pinecone.get(hostOrKey, collection, ids, $configuration) - Get the vectors with the specified `ids`")
+    @Description("apoc.vectordb.pinecone.get(hostOrKey, index, ids, $configuration) - Get the vectors with the specified `ids`")
     public Stream<VectorDbUtil.EmbeddingResult> get(@Name("hostOrKey") String hostOrKey,
-                                                      @Name("collection") String collection,
+                                                      @Name("index") String index,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
         setReadOnlyMappingMode(configuration);
-        return getCommon(hostOrKey, collection, ids, configuration);
+        return getCommon(hostOrKey, index, ids, configuration);
     }
 
     @Procedure(value = "apoc.vectordb.pinecone.getAndUpdate", mode = Mode.WRITE)
-    @Description("apoc.vectordb.pinecone.getAndUpdate(hostOrKey, collection, ids, $configuration) - Get the vectors with the specified `ids`")
+    @Description("apoc.vectordb.pinecone.getAndUpdate(hostOrKey, index, ids, $configuration) - Get the vectors with the specified `ids`")
     public Stream<VectorDbUtil.EmbeddingResult> getAndUpdate(@Name("hostOrKey") String hostOrKey,
-                                                      @Name("collection") String collection,
+                                                      @Name("index") String index,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration);
+        return getCommon(hostOrKey, index, ids, configuration);
     }
 
-    private Stream<VectorDbUtil.EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration) throws Exception {
+    private Stream<VectorDbUtil.EmbeddingResult> getCommon(String hostOrKey, String index, List<Object> ids, Map<String, Object> configuration) throws Exception {
         String url = "%s/vectors/fetch";
-        Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
+        Map<String, Object> config = getVectorDbInfo(hostOrKey, index, configuration, url);
         
-        VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromGet(config, procedureCallContext, ids, collection);
+        VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromGet(config, procedureCallContext, ids, index);
         
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx,
                 v -> {
@@ -178,33 +178,33 @@ public class Pinecone {
     }
 
     @Procedure(value = "apoc.vectordb.pinecone.query")
-    @Description("apoc.vectordb.pinecone.query(hostOrKey, collection, vector, filter, limit, $configuration) - Retrieve closest vectors the the defined `vector`, `limit` of results,  in the collection with the name specified in the 2nd parameter")
+    @Description("apoc.vectordb.pinecone.query(hostOrKey, index, vector, filter, limit, $configuration) - Retrieve closest vectors the the defined `vector`, `limit` of results,  in the index with the name specified in the 2nd parameter")
     public Stream<VectorDbUtil.EmbeddingResult> query(@Name("hostOrKey") String hostOrKey,
-                                                      @Name("collection") String collection,
+                                                      @Name("index") String index,
                                                       @Name(value = "vector", defaultValue = "[]") List<Double> vector,
                                                       @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                       @Name(value = "limit", defaultValue = "10") long limit,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
         setReadOnlyMappingMode(configuration);
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration);
+        return queryCommon(hostOrKey, index, vector, filter, limit, configuration);
     }
 
     @Procedure(value = "apoc.vectordb.pinecone.queryAndUpdate", mode = Mode.WRITE)
-    @Description("apoc.vectordb.pinecone.queryAndUpdate(hostOrKey, collection, vector, filter, limit, $configuration) - Retrieve closest vectors the the defined `vector`, `limit` of results,  in the collection with the name specified in the 2nd parameter")
+    @Description("apoc.vectordb.pinecone.queryAndUpdate(hostOrKey, index, vector, filter, limit, $configuration) - Retrieve closest vectors the the defined `vector`, `limit` of results,  in the index with the name specified in the 2nd parameter")
     public Stream<VectorDbUtil.EmbeddingResult> queryAndUpdate(@Name("hostOrKey") String hostOrKey,
-                                                      @Name("collection") String collection,
+                                                      @Name("index") String index,
                                                       @Name(value = "vector", defaultValue = "[]") List<Double> vector,
                                                       @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                       @Name(value = "limit", defaultValue = "10") long limit,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration);
+        return queryCommon(hostOrKey, index, vector, filter, limit, configuration);
     }
 
-    private Stream<VectorDbUtil.EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration) throws Exception {
+    private Stream<VectorDbUtil.EmbeddingResult> queryCommon(String hostOrKey, String index, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration) throws Exception {
         String url = "%s/query";
-        Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
+        Map<String, Object> config = getVectorDbInfo(hostOrKey, index, configuration, url);
 
-        VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromQuery(config, procedureCallContext, vector, filter, limit, collection);
+        VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromQuery(config, procedureCallContext, vector, filter, limit, index);
         
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx,
                 v -> {
@@ -215,7 +215,7 @@ public class Pinecone {
     }
 
     private Map<String, Object> getVectorDbInfo(
-            String hostOrKey, String collection, Map<String, Object> configuration, String templateUrl) {
-        return getCommonVectorDbInfo(hostOrKey, collection, configuration, templateUrl, DB_HANDLER);
+            String hostOrKey, String index, Map<String, Object> configuration, String templateUrl) {
+        return getCommonVectorDbInfo(hostOrKey, index, configuration, templateUrl, DB_HANDLER);
     }
 }

--- a/extended/src/main/java/apoc/vectordb/Pinecone.java
+++ b/extended/src/main/java/apoc/vectordb/Pinecone.java
@@ -47,7 +47,7 @@ public class Pinecone {
     public Stream<MapResult> getInfo(@Name("hostOrKey") String hostOrKey,
                                               @Name("collection") String collection,
                                               @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        String url = "%s/collections/%s";
+        String url = "%s/indexes/%s";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
 
         methodAndPayloadNull(config);

--- a/extended/src/main/java/apoc/vectordb/PineconeHandler.java
+++ b/extended/src/main/java/apoc/vectordb/PineconeHandler.java
@@ -53,7 +53,7 @@ public class PineconeHandler implements VectorDbHandler {
          *  that makes the request to respond 200 OK, but returns an empty result 
          */
         @Override
-        public <T> VectorEmbeddingConfig fromGet(Map<String, Object> config, ProcedureCallContext procedureCallContext, List<T> ids, String collection) {
+        public <T> VectorEmbeddingConfig fromGet(Map<String, Object> config, ProcedureCallContext procedureCallContext, List<T> ids, String index) {
             List<String> fields = procedureCallContext.outputFields().toList();
             
             config.put(BODY_KEY, null);
@@ -74,7 +74,7 @@ public class PineconeHandler implements VectorDbHandler {
         }
 
         @Override
-        public VectorEmbeddingConfig fromQuery(Map<String, Object> config, ProcedureCallContext procedureCallContext, List<Double> vector, Object filter, long limit, String collection) {
+        public VectorEmbeddingConfig fromQuery(Map<String, Object> config, ProcedureCallContext procedureCallContext, List<Double> vector, Object filter, long limit, String index) {
             List<String> fields = procedureCallContext.outputFields().toList();
 
             Map<String, Object> additionalBodies = map("vector", vector,

--- a/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
@@ -71,12 +71,16 @@ public class VectorDbUtil {
      * Retrieve, if exists, the properties stored via `apoc.vectordb.configure` procedure
      */
     private static Map<String, Object> getSystemDbProps(String hostOrKey, VectorDbHandler handler) {
-        Map<String, Object> props = withSystemDb(transaction -> {
-            Label label = Label.label(handler.getLabel());
-            Node node = transaction.findNode(label, SystemPropertyKeys.name.name(), hostOrKey);
-            return node == null ? Map.of() : node.getAllProperties();
-        });
-        return props;
+        try {
+            Map<String, Object> props = withSystemDb(transaction -> {
+                Label label = Label.label(handler.getLabel());
+                Node node = transaction.findNode(label, SystemPropertyKeys.name.name(), hostOrKey);
+                return node == null ? Map.of() : node.getAllProperties();
+            });
+            return props;
+        } catch (Exception e) {
+            return Map.of();
+        }
     }
 
     /**

--- a/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
@@ -79,6 +79,7 @@ public class VectorDbUtil {
             });
             return props;
         } catch (Exception e) {
+            // Fallback in case of null keys/values
             return Map.of();
         }
     }

--- a/extended/src/main/java/apoc/vectordb/VectorEmbeddingHandler.java
+++ b/extended/src/main/java/apoc/vectordb/VectorEmbeddingHandler.java
@@ -15,12 +15,7 @@ public interface VectorEmbeddingHandler {
                                       List<T> ids,
                                       String collection);
 
-    VectorEmbeddingConfig fromQuery(Map<String, Object> config,
-                                    ProcedureCallContext procedureCallContext,
-                                    List<Double> vector,
-                                    Object filter,
-                                    long limit,
-                                    String collection);
+    VectorEmbeddingConfig fromQuery(Map<String, Object> config, ProcedureCallContext procedureCallContext, List<Double> vector, Object filter, long limit, String index);
 
     default VectorEmbeddingConfig populateApiBodyRequest(VectorEmbeddingConfig config,
                                                         Map<String, Object> additionalBodies) {

--- a/extended/src/test/java/apoc/vectordb/PineconeTest.java
+++ b/extended/src/test/java/apoc/vectordb/PineconeTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import static apoc.ml.Prompt.API_KEY_CONF;
 import static apoc.ml.RestAPIConfig.HEADERS_KEY;
 import static apoc.util.ExtendedTestUtil.assertFails;
+import static apoc.util.ExtendedTestUtil.testRetryCallEventually;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testCallEmpty;
@@ -76,9 +77,9 @@ public class PineconeTest {
 
         ADMIN_AUTHORIZATION = map("Api-Key", API_KEY);
         ADMIN_HEADER_CONF  = map(HEADERS_KEY, ADMIN_AUTHORIZATION);
-        
-        testCall(db, "CALL apoc.vectordb.pinecone.createCollection($host, $coll, 'cosine', 4, $conf)",
-                map("host", null, "coll", collName,
+
+        testRetryCallEventually(db, "CALL apoc.vectordb.pinecone.createCollection($host, $coll, 'cosine', 4, $conf)",
+                map("host", HOST, "coll", collName,
                         "conf", map(HEADERS_KEY, ADMIN_AUTHORIZATION, 
                                     "body", map("spec", map("serverless", map("cloud", "aws", "region", "us-east-1")) )
                         )
@@ -86,9 +87,13 @@ public class PineconeTest {
                 r -> {
                     Map value = (Map) r.get("value");
                     assertEquals(map("ready", false, "state", "Initializing"), value.get("status"));
-                });
+                    HOST = "https://" + value.get("host");
+                }, 5L);
 
-        testCall(db, """
+        // the upsert takes a while
+        Util.sleep(5000);
+
+        testResult(db, """
                         CALL apoc.vectordb.pinecone.upsert($host, $coll,
                         [
                             {id: '1', vector: [0.05, 0.61, 0.76, 0.74], metadata: {city: "Berlin", foo: "one"}},
@@ -96,16 +101,17 @@ public class PineconeTest {
                         ],
                         $conf)
                         """,
-                map("host", "https://test-collection-ilx67g5.svc.aped-4627-b74a.pinecone.io",
+                map("host", HOST,
                         "coll", collName,
                         "conf", ADMIN_HEADER_CONF),
                 r -> {
-                    Map value = (Map) r.get("value");
+                    Map<String, Object> row = r.next();
+                    Map value = (Map) row.get("value");
                     assertEquals(2L, value.get("upsertedCount"));
                 });
         
         // the upsert takes a while
-        Util.sleep(5000);
+        Util.sleep(20000);
     }
 
     @AfterClass
@@ -130,7 +136,7 @@ public class PineconeTest {
     @Test
     public void getInfo() {
         testResult(db, "CALL apoc.vectordb.pinecone.info($host, $coll, $conf) ",
-                map("host", HOST, "coll", collName,
+                map("host", null, "coll", collName,
                         "conf", map(ALL_RESULTS_KEY, true, HEADERS_KEY, ADMIN_AUTHORIZATION)
                 ),
                 r -> {
@@ -142,12 +148,12 @@ public class PineconeTest {
     
     @Test
     public void getInfoNotExistentCollection() {
-        assertFails(db, "CALL apoc.vectordb.pinecone.info($host, 'wrong_collection', $conf) ",
-                map("host", HOST, "coll", collName,
+        String wrongCollection = "wrong_collection";
+        assertFails(db, "CALL apoc.vectordb.pinecone.info($host, $coll, $conf)",
+                map("host", null, "coll", wrongCollection,
                         "conf", map(ALL_RESULTS_KEY, true, HEADERS_KEY, ADMIN_AUTHORIZATION)
                 ),
-                "Server returned HTTP response code: 500"
-        );
+                "java.io.FileNotFoundException: https://api.pinecone.io/indexes/" + wrongCollection);
     }
 
     @Test
@@ -201,7 +207,7 @@ public class PineconeTest {
                 });
 
         // the upsert takes a while
-        Util.sleep(5000);
+        Util.sleep(10000);
 
         testCall(db, "CALL apoc.vectordb.pinecone.delete($host, $coll, ['3', '4'], $conf) ",
                 map("host", HOST, "coll", collName, "conf", ADMIN_HEADER_CONF),

--- a/extended/src/test/java/apoc/vectordb/PineconeTest.java
+++ b/extended/src/test/java/apoc/vectordb/PineconeTest.java
@@ -16,6 +16,7 @@ import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static apoc.ml.Prompt.API_KEY_CONF;
 import static apoc.ml.RestAPIConfig.HEADERS_KEY;
@@ -51,7 +52,7 @@ public class PineconeTest {
     private static String API_KEY;
     private static String HOST;
     
-    private static final String collName = "test-collection";
+    private static final String collName = UUID.randomUUID().toString();
 
     @ClassRule
     public static TemporaryFolder storeDir = new TemporaryFolder();


### PR DESCRIPTION
Al momento i test passano, ma ho notato che entra 2 volte nel teardown andando in errore al secondo passaggio sulla deleteCollection

```sh
`apoc.vectordb.pinecone.deleteCollection`: Caused by: java.io.IOException: Server returned HTTP response code: 502 for URL: https://api.pinecone.io/indexes/test-collection
```
  -
  -
  -
