### PR TITLE
WIP 4253: Missing apache arrow/jsonParams documentation

### DIFF
--- a/docs/asciidoc/modules/ROOT/nav.adoc
+++ b/docs/asciidoc/modules/ROOT/nav.adoc
@@ -28,6 +28,7 @@ include::partial$generated-documentation/nav.adoc[]
     ** xref::import/html.adoc[]
     ** xref::import/parquet.adoc[]
     ** xref::import/gexf.adoc[]
+    ** xref::import/load-json.adoc[]
 
 * xref:export/index.adoc[]
     ** xref::export/xls.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/import/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/index.adoc
@@ -14,3 +14,4 @@ For more information on these procedures, see:
 * xref::import/html.adoc[]
 * xref::import/parquet.adoc[]
 * xref::import/gexf.adoc[]
+* xref::import/load-json.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
@@ -39,4 +39,3 @@ include::includes/enableFileImport.adoc[]
 == Usage Examples
 include::partial$usage/apoc.load.jsonParams.adoc[]
 
-xref::import/load-json.adoc[More documentation of apoc.load.jsonParams,role=more information]

--- a/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
@@ -1,0 +1,42 @@
+[[apoc.load.jsonParams]]
+= Load JSON
+:description: This section contains reference documentation for the apoc.load.jsonParams procedure.
+
+label:procedure[] label:apoc-core[]
+
+[.emphasis]
+apoc.load.jsonParams('urlOrKeyOrBinary',{header:value},payload, config) YIELD value - load from JSON URL (e.g. web-api) while sending headers / payload to import JSON as stream of values if the JSON was an array or a single value if it was a map
+
+== Signature
+
+[source]
+----
+apoc.load.jsonParams(urlOrKeyOrBinary :: ANY?, headers :: MAP?, payload :: STRING?, path =  :: STRING?, config = {} :: MAP?) :: (value :: MAP?)
+----
+
+== Input parameters
+[.procedures, opts=header]
+|===
+| Name | Type | Default
+|urlOrKeyOrBinary|ANY?|null
+|headers|MAP?|null
+|payload|STRING?|null
+|path|STRING?|
+|config|MAP?|{}
+|===
+
+== Output parameters
+[.procedures, opts=header]
+|===
+| Name | Type
+|value|MAP?
+|===
+
+== Reading from a file
+include::includes/enableFileImport.adoc[]
+
+[[usage-apoc.load.jsonParams]]
+== Usage Examples
+include::partial$usage/apoc.load.jsonParams.adoc[]
+
+xref::import/load-json.adoc[More documentation of apoc.load.jsonParams,role=more information]

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.jsonParams.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.jsonParams.adoc
@@ -1,0 +1,27 @@
+We can perform a POST request to a JSON endpoint by setting the config parameter `method` to `POST`.
+We'll also use xref::https://neo4j.com/docs/apoc/5/overview/apoc.convert/apoc.convert.toJson[apoc.convert.toJson] (included in APOC core) to construct a JSON payload from a Cypher map.
+
+The following makes a POST request to Neo4j's search API:
+
+[source,cypher]
+----
+CALL apoc.load.jsonParams(
+  "https://neo4j.com/docs/search/",
+  {method: "POST"},
+  apoc.convert.toJson({query: "subquery", version: "4.0"})
+);
+----
+
+
+.Results
+[options="header"]
+|===
+| value
+| {description: "The CALL {} clause evaluates a subquery that returns some values.", weight: 0.6460227966308594, title: "3.16. CALL {} (subquery) - Chapter 3. Clauses", uri: "https://neo4j.com/docs/cypher-manual/4.0/clauses/call-subquery/"}
+| {description: "This section provides examples of queries and Cypher commands that can be used with Neo4j Fabric.", weight: 0.05099273845553398, title: "7.3. Queries - Chapter 7. Fabric", uri: "https://neo4j.com/docs/operations-manual/4.0/fabric/queries/"}
+| {description: "WHERE adds constraints to the patterns in a MATCH or OPTIONAL MATCH clause or filters the results of a WITH clause.", weight: 0.03291567042469978, title: "3.6. WHERE - Chapter 3. Clauses", uri: "https://neo4j.com/docs/cypher-manual/4.0/clauses/where/"}
+| {description: "This appendix contains the recommended style when writing Cypher queries.", weight: 0.031550146639347076, title: "Appendix A. Cypher styleguide - The Neo4j Cypher Manual v4.0", uri: "https://neo4j.com/docs/cypher-manual/4.0/styleguide/"}
+| {description: "This section contains information on all the clauses in the Cypher query language.", weight: 0.02944066934287548, title: "Chapter 3. Clauses - The Neo4j Cypher Manual v4.0", uri: "https://neo4j.com/docs/cypher-manual/4.0/clauses/"}
+| {description: "", weight: 0.01821548491716385, title: "2.3. Expressions - Chapter 2. Syntax", uri: "https://neo4j.com/docs/cypher-manual/4.0/syntax/expressions/"}
+
+|===


### PR DESCRIPTION
Rivedere l'ultima riga del file load-json.adoc dove dice `More documentation of apoc.load.jsonParams,role=more information`. Forse è da eliminare?

