### PR TITLE
Fixes 3610: Add advanced SQL analytics to streaming cypher rows before returning results to the client

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
@@ -2,7 +2,8 @@
 = Load JDBC (RDBMS)
 :description: This section describes procedures that can be used to import data from databases that have JDBC support.
 
-
+// todo - aggiungere documentazione qui 
+//  e dire che per usare PaperaDB dobbiamo importare il driver da qui: https://repo1.maven.org/maven2/org/duckdb/duckdb_jdbc/1.1.3/duckdb_jdbc-1.1.3.jar
 
 Data Integration is an important topic.
 Reading data from relational databases to create and augment data models is a very helpful exercise.

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
@@ -2,8 +2,7 @@
 = Load JDBC (RDBMS)
 :description: This section describes procedures that can be used to import data from databases that have JDBC support.
 
-// todo - aggiungere documentazione qui 
-//  e dire che per usare PaperaDB dobbiamo importare il driver da qui: https://repo1.maven.org/maven2/org/duckdb/duckdb_jdbc/1.1.3/duckdb_jdbc-1.1.3.jar
+If you want to use DuckDB you should download and import the driver from https://repo1.maven.org/maven2/org/duckdb/duckdb_jdbc/1.1.3/duckdb_jdbc-1.1.3.jar
 
 Data Integration is an important topic.
 Reading data from relational databases to create and augment data models is a very helpful exercise.
@@ -525,4 +524,135 @@ CALL apoc.load.jdbcUpdate('jdbc:derby:derbyDB','UPDATE PERSON SET NAME = ? WHERE
 [source,cypher]
 ----
 CALL apoc.load.jdbc('jdbc:derby:derbyDB', 'PERSON',[],{credentials:{user:'apoc',password:'Ap0c!#Db'}})
+----
+
+== LOAD JDBC - ANALYTICS
+
+You can reproduce the following queries using some nodes:
+
+[source, cypher]
+----
+CREATE (:Movie {title:'The Matrix', language: 'en', released:1999, tagline:'Welcome to the Real World', qty: 5})
+CREATE (:Movie {title:'The Matrix Reloaded', language: 'en', released:2003, tagline:'Free your mind', qty: 6})
+CREATE (:Movie {title:'The Matrix Revolutions', language: 'en', released:2003, tagline:'Everything that has a beginning has an end', qty: 11})
+CREATE (:Movie {title:"The Devil's Advocate", language: 'en', released:1997, tagline:'Evil has its winning ways', qty: 3})
+CREATE (:Movie {title:"A Few Good Men", language: 'it', released:1992, tagline:"In the heart of the nation's capital, in a courthouse of the U.S. government, one man will stop at nothing to keep his honor, and one will stop at nothing to find the truth.", qty: 7})
+CREATE (:Movie {title:"Top Gun", released:1986, language: 'it', tagline:'I feel the need, the need for speed.', qty: 12})
+----
+
+=== DuckDB
+
+Example to get the rank of the current row with gaps.
+Fields of the SQL query should be consistent with the Cypher query.
+For detailed information go to https://duckdb.org/docs/sql/functions/window_functions.html#rank
+
+It is possible to specify a provider in the config parameters.
+The default value is "DUCKDB".
+
+[source,cypher]
+----
+CALL apoc.load.jdbc.analytics(
+  "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline",
+  $url,
+  "SELECT
+   title,
+   released,
+   language,
+   tagline,
+   RANK() OVER (PARTITION BY language ORDER BY released DESC) AS rank
+   FROM temp_table
+   ORDER BY rank, title, tagline;"
+)
+----
+
+Another example to get a Pivot table using window functions
+
+[source,cypher]
+----
+CALL apoc.load.jdbc.analytics(
+  "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline",
+  $url,
+  "WITH ranked_data AS (
+   SELECT
+   title,
+   released,
+   language,
+   tagline,
+   qty,
+   ROW_NUMBER() OVER (PARTITION BY language ORDER BY released DESC) AS rank
+   FROM temp_table
+   ORDER BY rank, title, tagline)
+
+   SELECT *
+   FROM ranked_data
+   PIVOT (
+      sum(qty)
+      FOR
+          language IN ('en', 'it')
+      GROUP BY released
+   )"
+)
+----
+
+=== MySQL
+
+Returns the rank of the current row within its partition, with gaps.
+For further information go to
+https://dev.mysql.com/doc/refman/8.4/en/window-function-descriptions.html#function_rank
+
+[source,cypher]
+----
+CALL apoc.load.jdbc.analytics(
+ "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline",
+ $url,
+ "SELECT
+   title,
+   released,
+   language,
+   tagline,
+  RANK() OVER (PARTITION BY language ORDER BY released DESC) AS 'rank'
+ FROM temp_table
+ ORDER BY title, tagline",
+ $params,
+ { provider: "MYSQL" })
+----
+
+Here an example of ROW_NUMBER window function with MySQL:
+
+[source,cypher]
+----
+CALL apoc.load.jdbc.analytics(
+ "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline",
+ $url,
+ "SELECT
+    title,
+    released,
+    language,
+    tagline,
+    ROW_NUMBER() OVER (PARTITION BY language ORDER BY released DESC) AS 'rank'
+  FROM temp_table
+  ORDER BY title, tagline",
+ $params,
+ { provider: "MYSQL" })
+----
+
+=== PostgreSQL
+
+Here some examples with Window functions.
+
+[source,cypher]
+----
+CALL apoc.load.jdbc.analytics(
+ "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline",
+ $url,
+ "SELECT
+  title,
+  released,
+  language,
+  tagline,
+  RANK() OVER (PARTITION BY language ORDER BY released DESC) rank
+  FROM temp_table
+  ORDER BY rank, title, tagline",
+ $params,
+ { provider: "POSTGRES" })
 ----

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
@@ -2,7 +2,7 @@
 = Load JDBC (RDBMS)
 :description: This section describes procedures that can be used to import data from databases that have JDBC support.
 
-If you want to use DuckDB you should download and import the driver from https://repo1.maven.org/maven2/org/duckdb/duckdb_jdbc/1.1.3/duckdb_jdbc-1.1.3.jar
+If you want to use DuckDB you should download and import the driver from https://repo1.maven.org/maven2/org/duckdb/duckdb_jdbc/1.1.3/duckdb_jdbc-1.1.3.jar[Maven Repository]
 
 Data Integration is an important topic.
 Reading data from relational databases to create and augment data models is a very helpful exercise.
@@ -528,6 +528,12 @@ CALL apoc.load.jdbc('jdbc:derby:derbyDB', 'PERSON',[],{credentials:{user:'apoc',
 
 == LOAD JDBC - ANALYTICS
 
+You can use the `apoc.load.jdbc.analytics(<cypherQuery>, <jdbcUrl>, <sqlQueryOverTemporaryTable>, $config)`
+to create a temporary table starting from a Cypher query
+and delegate complex analytics to the database defined JDBC URL.
+
+Please note that the returning SQL column names have to be consistent with the one provided by the Cypher query
+
 You can reproduce the following queries using some nodes:
 
 [source, cypher]
@@ -638,7 +644,7 @@ CALL apoc.load.jdbc.analytics(
 
 === PostgreSQL
 
-Here some examples with Window functions.
+Here an example with Window functions.
 
 [source,cypher]
 ----

--- a/extended-it/src/test/java/apoc/load/MySQLJdbcTest.java
+++ b/extended-it/src/test/java/apoc/load/MySQLJdbcTest.java
@@ -1,14 +1,15 @@
 package apoc.load;
 
-import apoc.util.s3.MySQLContainerExtension;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import apoc.util.s3.MySQLContainerExtension;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -18,8 +19,11 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
+import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Enclosed.class)
@@ -36,7 +40,12 @@ public class MySQLJdbcTest extends AbstractJdbcTest {
         @BeforeClass
         public static void setUpContainer() {
             mysql.start();
-            TestUtil.registerProcedure(db, Jdbc.class);
+            TestUtil.registerProcedure(db, Jdbc.class, Analytics.class);
+            String movies = Util.readResourceFile("movies-analytics.cypher");
+            try (Transaction tx = db.beginTx()) {
+                tx.execute(movies);
+                tx.commit();
+            }
         }
 
         @AfterClass
@@ -53,6 +62,119 @@ public class MySQLJdbcTest extends AbstractJdbcTest {
         @Test
         public void testIssue3496() {
             MySQLJdbcTest.testIssue3496(db, mysql);
+        }
+
+        @Test
+        public void testLoadJdbcAnalytics() {
+            String cypher = "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline";
+
+            String sql = """
+                SELECT
+                  title,
+                  released,
+                  language,
+                  tagline,
+                 RANK() OVER (PARTITION BY language ORDER BY released DESC) AS 'rank'
+                FROM temp_table
+                ORDER BY title, tagline
+               """;
+            testResult(db, "CALL apoc.load.jdbc.analytics($queryCypher, $url, $sql, [], $config)",
+                    map(
+                            "queryCypher", cypher,
+                            "sql", sql,
+                            "url", mysql.getJdbcUrl(),
+                            "config", Map.of("provider", Analytics.Provider.MYSQL.name())
+                    ),
+                    r -> {
+                        Map<String, Object> row = r.next();
+                        var result = (Map) row.get("row");
+                        var rank = (String) result.get("rank");
+                        assertEquals("1", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("4", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("3", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("1", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("1", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("2", rank);
+
+                        assertFalse(r.hasNext());
+                    });
+        }
+
+        @Test
+        public void testLoadJdbcAnalyticsWindow() {
+            String cypher = "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline, n.qty AS qty";
+
+            String sql = """
+                SELECT
+                  title,
+                  released,
+                  language,
+                  tagline,
+                  ROW_NUMBER() OVER (PARTITION BY language ORDER BY released DESC) AS 'rank'
+                FROM temp_table
+                ORDER BY title, tagline
+               """;
+
+            testResult(db, "CALL apoc.load.jdbc.analytics($queryCypher, $url, $sql, [], $config)",
+                    map(
+                            "queryCypher", cypher,
+                            "sql", sql,
+                            "url", mysql.getJdbcUrl(),
+                            "config", Map.of("provider", Analytics.Provider.MYSQL.name())
+                    ),
+                    r -> {
+                        Map<String, Object> row = r.next();
+                        var result = (Map) row.get("row");
+                        var rank = (String) result.get("rank");
+                        assertEquals("1", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("4", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("3", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("1", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("2", rank);
+
+                        row = r.next();
+                        result = (Map) row.get("row");
+                        rank = (String) result.get("rank");
+                        assertEquals("2", rank);
+
+                        assertFalse(r.hasNext());
+                    });
         }
     }
     

--- a/extended-it/src/test/java/apoc/load/MySQLJdbcTest.java
+++ b/extended-it/src/test/java/apoc/load/MySQLJdbcTest.java
@@ -41,7 +41,7 @@ public class MySQLJdbcTest extends AbstractJdbcTest {
         public static void setUpContainer() {
             mysql.start();
             TestUtil.registerProcedure(db, Jdbc.class, Analytics.class);
-            String movies = Util.readResourceFile("movies-analytics.cypher");
+            String movies = Util.readResourceFile(MOVIES_CYPHER_FILE);
             try (Transaction tx = db.beginTx()) {
                 tx.execute(movies);
                 tx.commit();

--- a/extended-it/src/test/java/apoc/load/PostgresJdbcTest.java
+++ b/extended-it/src/test/java/apoc/load/PostgresJdbcTest.java
@@ -46,7 +46,7 @@ public class PostgresJdbcTest extends AbstractJdbcTest {
         TestUtil.registerProcedure(db,Jdbc.class, Periodic.class, Strings.class, Analytics.class);
         db.executeTransactionally("CALL apoc.load.driver('org.postgresql.Driver')");
 
-        String movies = Util.readResourceFile("movies-analytics.cypher");
+        String movies = Util.readResourceFile(MOVIES_CYPHER_FILE);
         try (Transaction tx = db.beginTx()) {
             tx.execute(movies);
             tx.commit();

--- a/extended-it/src/test/java/apoc/load/PostgresJdbcTest.java
+++ b/extended-it/src/test/java/apoc/load/PostgresJdbcTest.java
@@ -10,6 +10,7 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -19,6 +20,7 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertArrayEquals;
@@ -41,8 +43,14 @@ public class PostgresJdbcTest extends AbstractJdbcTest {
     public static void setUp() throws Exception {
         postgress = new PostgreSQLContainer().withInitScript("init_postgres.sql");
         postgress.start();
-        TestUtil.registerProcedure(db,Jdbc.class, Periodic.class, Strings.class);
+        TestUtil.registerProcedure(db,Jdbc.class, Periodic.class, Strings.class, Analytics.class);
         db.executeTransactionally("CALL apoc.load.driver('org.postgresql.Driver')");
+
+        String movies = Util.readResourceFile("movies-analytics.cypher");
+        try (Transaction tx = db.beginTx()) {
+            tx.execute(movies);
+            tx.commit();
+        }
     }
 
     @AfterClass
@@ -132,6 +140,119 @@ public class PostgresJdbcTest extends AbstractJdbcTest {
         testResult(db, query, config, this::assertPeriodicIterate);
 
         assertPgStatActivityHasOnlyActiveState();
+    }
+
+    @Test
+    public void testLoadJdbcAnalytics() {
+        String cypher = "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline";
+
+        String sql = """
+            SELECT
+            title,
+            released,
+            language,
+            tagline,
+            RANK() OVER (PARTITION BY language ORDER BY released DESC) rank
+            FROM temp_table
+            ORDER BY rank, title, tagline;
+            """;
+        testResult(db, "CALL apoc.load.jdbc.analytics($queryCypher, $url, $sql, [], $config)",
+                map(
+                        "queryCypher", cypher,
+                        "sql", sql,
+                        "url", getUrl(postgress),
+                        "config", Map.of("provider", Analytics.Provider.POSTGRES.name())
+                ),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    var result = (Map) row.get("row");
+                    var rank = (long) result.get("rank");
+                    assertEquals(1, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(1, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(1, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(2, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(3, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(4, rank);
+
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void testLoadJdbcAnalyticsWindow() {
+        String cypher = "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline, n.qty AS qty";
+
+        String sql = """
+                SELECT
+                  title,
+                  released,
+                  language,
+                  tagline,
+                  ROW_NUMBER() OVER (PARTITION BY language ORDER BY released DESC) rank
+                FROM temp_table
+                ORDER BY rank, title, tagline
+               """;
+
+        testResult(db, "CALL apoc.load.jdbc.analytics($queryCypher, $url, $sql, [], $config)",
+                map(
+                        "queryCypher", cypher,
+                        "sql", sql,
+                        "url", getUrl(postgress),
+                        "config", Map.of("provider", Analytics.Provider.MYSQL.name())
+                ),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    var result = (Map) row.get("row");
+                    var rank = (long) result.get("rank");
+                    assertEquals(1, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(1, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(2, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(2, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(3, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(4, rank);
+
+                    assertFalse(r.hasNext());
+                });
     }
 
     private static void assertPgStatActivityHasOnlyActiveState() {

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -164,6 +164,7 @@ dependencies {
     testImplementation group: 'com.opencsv', name: 'opencsv', version: '5.7.1', {
         exclude group: 'org.apache.commons', module: 'commons-collections4'
     }
+    testImplementation group: 'org.duckdb', name: 'duckdb_jdbc', version: '1.1.3'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/extended/src/main/java/apoc/load/Analytics.java
+++ b/extended/src/main/java/apoc/load/Analytics.java
@@ -1,0 +1,132 @@
+package apoc.load;
+
+import apoc.Extended;
+import apoc.result.RowResult;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static apoc.load.Jdbc.executeUpdate;
+
+
+
+// TODO - scrivere sulla pr che abbiamo testato anche le apoc.load.jdbc* con DuckDB e fixato eventuali errori
+
+@Extended
+public class Analytics {
+
+    @Context
+    public Log log;
+
+    @Context
+    public GraphDatabaseService db;
+
+    @Context
+    public Transaction tx;
+
+
+    // TODO - PRENDERE COME ESEMPI https://chatgpt.com/share/67530793-c0d0-800c-a4fc-9ae01e098de3
+    // TODO - testare principalmente per DuckDB
+    
+    //         TODO poi provare a testare con altri db, scopiazzando i container da MySQLJdbcTest e  PostgresJdbcTest
+    
+    //          se necessario, mettere qualcosa tipo config.getOrDefault("database", "duckDB") 
+    //              e fare degli if-else/switch/etc.. per differenziare le query sql
+    
+    @Procedure("apoc.load.jdbc.analytics")
+    // TODO 
+    @Description("TODO - DESCRIZIONE")
+    public Stream<RowResult> aggregate(
+            @Name("neo4jQuery") String neo4jQuery,
+            @Name("jdbc") String urlOrKey,
+            @Name("sqlQuery") String sqlQuery,
+            @Name(value = "params", defaultValue = "[]") List<Object> params,
+            @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
+
+        // TODO - scrivere sulla PR: add handling: some SQL database like Microsoft SQL Server create temp table in a different way
+        //      e.g. CREATE TABLE #table_name (column_name datatype);
+        //      document it
+
+        // TODO step 1: temp table creation partendo dalla neo4jQuery
+        //  mettere al posto di query la creazione di una tabella temporanea
+        //  facendo leva su tx.execute(..) o db.executeTransactionally(...) e recuperandosi i risultati
+         
+        /* ad esempio, se passo la query neo4j
+            SELECT 
+                actor,
+                genre,
+                SUM(movies_count) AS movies_count
+            FROM movies_data
+            GROUP BY actor, genre
+            ORDER BY movies_count DESC
+        
+        la tabella sarà qualcosa tipo:
+            
+            CREATE TEMPORARY TABLE movies_data AS 
+            SELECT * FROM 
+            (VALUES
+                ('Keanu Reeves', 'Sci-Fi', 3),
+                ('Carrie-Anne Moss', 'Sci-Fi', 2),
+                ('Laurence Fishburne', 'Sci-Fi', 3),
+                ('Keanu Reeves', 'Action', 4),
+                ('Will Smith', 'Action', 5)
+            ) AS t(actor, genre, movies_count);
+            
+         */
+        executeUpdate(urlOrKey, "<TODO>", config, log, params);
+        
+        // TODO step 2: fare dei test in cui passo una query che interroga la tabella temporanea
+        /* ad esempio
+        WITH ranked_data AS (
+            SELECT 
+                category_column, 
+                pivot_column, 
+                value_column,
+                ROW_NUMBER() OVER (PARTITION BY category_column ORDER BY value_column DESC) AS rank
+            FROM neo4j_data
+            )
+         */
+        
+        // todo - altri test con query sql, tipo questo
+        /*
+        SELECT 
+            actor,
+            genre,
+            movies_count,
+            RANK() OVER (PARTITION BY genre ORDER BY movies_count DESC) AS rank
+        FROM movies_data;
+         */
+        
+        /*
+        
+         */
+        executeUpdate(urlOrKey, sqlQuery, config, log, params);
+
+        // TODO  step 3: return result
+        return null;
+    }
+
+
+    /* TODO scrivere questa cosa sulla PR:
+        meglio non aggregation, così è più personalizzabile, posso scegliere quali risultati ottenere e come ottenerli 
+        altrimenti per fare qualcosa come sotto, con movies_count dovrei mettere un parametri aggKeys e fare cose strane
+        
+            MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)
+            RETURN 
+                p.name AS actor, 
+                m.genre AS genre, 
+                r.roles AS roles, 
+                COUNT(m) AS movies_count
+     */
+
+
+    
+}

--- a/extended/src/main/java/apoc/load/Analytics.java
+++ b/extended/src/main/java/apoc/load/Analytics.java
@@ -49,7 +49,7 @@ public class Analytics {
     public Transaction tx;
 
     @Procedure("apoc.load.jdbc.analytics")
-    @Description("TODO - DESCRIZIONE")
+    @Description("apoc.load.jdbc.analytics(<cypherQuery>, <jdbcUrl>, <sqlQueryOverTemporaryTable>, $config) - to create a temporary table starting from a Cypher query and delegate complex analytics to the database defined JDBC URL ")
     public Stream<RowResult> aggregate(
             @Name("neo4jQuery") String neo4jQuery,
             @Name("jdbc") String urlOrKey,
@@ -98,9 +98,7 @@ public class Analytics {
 
         // Insert data
         executeUpdate(urlOrKey, queryInsert.get(), config, log, connection, params.toArray(new Object[params.size()]));
-        // TODO: documentare che la query SQL deve avere colonne consistenti con la query neo4j
 
-        // TODO step 2: fare dei test in cui passo una query che interroga la tabella temporanea
         try {
             return executeQuery(urlOrKey, sqlQuery, config, log, connection, params.toArray(new Object[params.size()]));
         } catch (Exception e) {

--- a/extended/src/main/java/apoc/load/Analytics.java
+++ b/extended/src/main/java/apoc/load/Analytics.java
@@ -2,6 +2,8 @@ package apoc.load;
 
 import apoc.Extended;
 import apoc.result.RowResult;
+import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.logging.Log;
@@ -10,10 +12,18 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static apoc.load.Jdbc.executeQuery;
 import static apoc.load.Jdbc.executeUpdate;
 
 
@@ -23,6 +33,11 @@ import static apoc.load.Jdbc.executeUpdate;
 @Extended
 public class Analytics {
 
+    enum Provider {
+        POSTGRES,
+        DUCKDB
+    }
+
     @Context
     public Log log;
 
@@ -31,7 +46,6 @@ public class Analytics {
 
     @Context
     public Transaction tx;
-
 
     // TODO - PRENDERE COME ESEMPI https://chatgpt.com/share/67530793-c0d0-800c-a4fc-9ae01e098de3
     // TODO - testare principalmente per DuckDB
@@ -58,8 +72,57 @@ public class Analytics {
         // TODO step 1: temp table creation partendo dalla neo4jQuery
         //  mettere al posto di query la creazione di una tabella temporanea
         //  facendo leva su tx.execute(..) o db.executeTransactionally(...) e recuperandosi i risultati
-         
+        AtomicReference<String> createTable = new AtomicReference<>("");
+        final Provider provider = Provider.valueOf((String) config.getOrDefault("provider", Provider.DUCKDB.name()));
+
+        switch (provider) {
+            case POSTGRES -> {
+                return null;
+            }
+            case DUCKDB -> createTable.set("""
+                CREATE TABLE temp_table 
+                """);
+        }
+        AtomicReference<String> columns = new AtomicReference<>();
+        Map<String, String> sqlTypes = new LinkedHashMap<>();
+        AtomicReference<String> queryInsert = new AtomicReference<>("INSERT INTO temp_table VALUES ");
+                db.executeTransactionally(neo4jQuery,
+                Map.of(),
+                r -> {
+                    List<String> sqlValues = new ArrayList<>();
+                    r.forEachRemaining(map -> {
+
+                        map.entrySet().stream()
+                                .sorted(Map.Entry.comparingByKey())
+                                .forEachOrdered(x -> sqlTypes.put(x.getKey(), mapSqlType(x.getValue())));
+
+                        final Collection<Object> values = map.entrySet().stream().sorted(Map.Entry.comparingByKey()).map(Map.Entry::getValue).toList();
+                        final String row = values.stream().map(x -> {
+                            final String stringValue = x.toString();
+                            if (x instanceof Number) return stringValue;
+                            return String.format("'%s'", stringValue.replace("'", "''"));
+                        }).collect(Collectors.joining(","));
+                        sqlValues.add("(" + row + ")");
+                    });
+//                    createTable.set(createTable.get() + StringUtils.join(sqlValues, ","));
+                    queryInsert.set(queryInsert.get() + StringUtils.join(sqlValues, ","));
+                    columns.set(r.columns().stream().sorted().collect(Collectors.joining(",")));
+//                    createTable.set(createTable.get() + " AS t("  + columns.get() + ");");
+                    return null;
+                });
+
+        createTable.set(createTable.get() + mapToString(sqlTypes));
+
+
+
         /* ad esempio, se passo la query neo4j
+
+            MATCH (n:Movie) RETURN n.actor as actor, n.genre as genre, COUNT(n) as movies_count
+
+            CREATE TEMPORARY TABLE table_name (
+                column_name datatype
+            );
+
             SELECT 
                 actor,
                 genre,
@@ -81,9 +144,26 @@ public class Analytics {
             ) AS t(actor, genre, movies_count);
             
          */
-        executeUpdate(urlOrKey, "<TODO>", config, log, params);
-        
+        final Stream<RowResult> rowResultStream = executeUpdate(urlOrKey,
+                createTable.get(), config
+                , log, params.toArray(new Object[params.size()]));
+        final RowResult rowResult = rowResultStream.findFirst().get();
+
+        final Stream<RowResult> insertResStream = executeUpdate(urlOrKey, queryInsert.get(), config, log, params.toArray(new Object[params.size()]));
+        final RowResult insertResult = insertResStream.findFirst().get();
+        // TODO: documentare che la query SQL deve avere colonne consistenti con la query neo4j
+
         // TODO step 2: fare dei test in cui passo una query che interroga la tabella temporanea
+        /*
+        SELECT
+    actor,
+    genre,
+    movies_count,
+    RANK() OVER (PARTITION BY genre ORDER BY movies_count DESC) AS rank
+        FROM temp_data
+        ORDER BY genre, rank;
+         */
+
         /* ad esempio
         WITH ranked_data AS (
             SELECT 
@@ -108,10 +188,25 @@ public class Analytics {
         /*
         
          */
-        executeUpdate(urlOrKey, sqlQuery, config, log, params);
 
         // TODO  step 3: return result
-        return null;
+        try {
+            return executeQuery(urlOrKey, sqlQuery, config, log, params.toArray(new Object[params.size()]));
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Make sure the SQL is consistent with Cypher query which has columns: %s", columns.get()));
+        }
+    }
+
+    private String mapSqlType(Object value) {
+        if (value instanceof Number) return "INTEGER";
+        else return "VARCHAR";
+    }
+
+    public String mapToString(Map<String, ?> map) {
+        String mapAsString = map.keySet().stream()
+                .map(key -> key + " " + map.get(key))
+                .collect(Collectors.joining(", ", "(", ")"));
+        return mapAsString;
     }
 
 

--- a/extended/src/main/java/apoc/load/Analytics.java
+++ b/extended/src/main/java/apoc/load/Analytics.java
@@ -1,6 +1,7 @@
 package apoc.load;
 
 import apoc.Extended;
+import apoc.load.util.LoadJdbcConfig;
 import apoc.result.RowResult;
 import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
@@ -12,6 +13,7 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
+import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -25,17 +27,16 @@ import java.util.stream.Stream;
 
 import static apoc.load.Jdbc.executeQuery;
 import static apoc.load.Jdbc.executeUpdate;
-
-
-
-// TODO - scrivere sulla pr che abbiamo testato anche le apoc.load.jdbc* con DuckDB e fixato eventuali errori
+import static apoc.load.util.JdbcUtil.getConnection;
+import static apoc.load.util.JdbcUtil.getUrlOrKey;
 
 @Extended
 public class Analytics {
 
     enum Provider {
         POSTGRES,
-        DUCKDB
+        DUCKDB,
+        MYSQL
     }
 
     @Context
@@ -47,42 +48,19 @@ public class Analytics {
     @Context
     public Transaction tx;
 
-    // TODO - PRENDERE COME ESEMPI https://chatgpt.com/share/67530793-c0d0-800c-a4fc-9ae01e098de3
-    // TODO - testare principalmente per DuckDB
-    
-    //         TODO poi provare a testare con altri db, scopiazzando i container da MySQLJdbcTest e  PostgresJdbcTest
-    
-    //          se necessario, mettere qualcosa tipo config.getOrDefault("database", "duckDB") 
-    //              e fare degli if-else/switch/etc.. per differenziare le query sql
-    
     @Procedure("apoc.load.jdbc.analytics")
-    // TODO 
     @Description("TODO - DESCRIZIONE")
     public Stream<RowResult> aggregate(
             @Name("neo4jQuery") String neo4jQuery,
             @Name("jdbc") String urlOrKey,
             @Name("sqlQuery") String sqlQuery,
             @Name(value = "params", defaultValue = "[]") List<Object> params,
-            @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
-
-        // TODO - scrivere sulla PR: add handling: some SQL database like Microsoft SQL Server create temp table in a different way
-        //      e.g. CREATE TABLE #table_name (column_name datatype);
-        //      document it
-
-        // TODO step 1: temp table creation partendo dalla neo4jQuery
-        //  mettere al posto di query la creazione di una tabella temporanea
-        //  facendo leva su tx.execute(..) o db.executeTransactionally(...) e recuperandosi i risultati
+            @Name(value = "config",defaultValue = "{}") Map<String, Object> config) throws Exception {
         AtomicReference<String> createTable = new AtomicReference<>("");
         final Provider provider = Provider.valueOf((String) config.getOrDefault("provider", Provider.DUCKDB.name()));
 
-        switch (provider) {
-            case POSTGRES -> {
-                return null;
-            }
-            case DUCKDB -> createTable.set("""
-                CREATE TABLE temp_table 
-                """);
-        }
+        createTable.set("CREATE TEMPORARY TABLE temp_table ");
+
         AtomicReference<String> columns = new AtomicReference<>();
         Map<String, String> sqlTypes = new LinkedHashMap<>();
         AtomicReference<String> queryInsert = new AtomicReference<>("INSERT INTO temp_table VALUES ");
@@ -94,7 +72,7 @@ public class Analytics {
 
                         map.entrySet().stream()
                                 .sorted(Map.Entry.comparingByKey())
-                                .forEachOrdered(x -> sqlTypes.put(x.getKey(), mapSqlType(x.getValue())));
+                                .forEachOrdered(x -> sqlTypes.put(x.getKey(), mapSqlType(provider, x.getValue())));
 
                         final Collection<Object> values = map.entrySet().stream().sorted(Map.Entry.comparingByKey()).map(Map.Entry::getValue).toList();
                         final String row = values.stream().map(x -> {
@@ -104,102 +82,43 @@ public class Analytics {
                         }).collect(Collectors.joining(","));
                         sqlValues.add("(" + row + ")");
                     });
-//                    createTable.set(createTable.get() + StringUtils.join(sqlValues, ","));
                     queryInsert.set(queryInsert.get() + StringUtils.join(sqlValues, ","));
                     columns.set(r.columns().stream().sorted().collect(Collectors.joining(",")));
-//                    createTable.set(createTable.get() + " AS t("  + columns.get() + ");");
                     return null;
                 });
 
         createTable.set(createTable.get() + mapToString(sqlTypes));
 
+        String url = getUrlOrKey(urlOrKey);
+        LoadJdbcConfig jdbcConfig = new LoadJdbcConfig(config);
+        Connection connection = (Connection) getConnection(url, jdbcConfig, Connection.class);
 
+        // Create temporary table
+        executeUpdate(urlOrKey, createTable.get(), config, log, connection, params.toArray(new Object[params.size()]));
 
-        /* ad esempio, se passo la query neo4j
-
-            MATCH (n:Movie) RETURN n.actor as actor, n.genre as genre, COUNT(n) as movies_count
-
-            CREATE TEMPORARY TABLE table_name (
-                column_name datatype
-            );
-
-            SELECT 
-                actor,
-                genre,
-                SUM(movies_count) AS movies_count
-            FROM movies_data
-            GROUP BY actor, genre
-            ORDER BY movies_count DESC
-        
-        la tabella sarà qualcosa tipo:
-            
-            CREATE TEMPORARY TABLE movies_data AS 
-            SELECT * FROM 
-            (VALUES
-                ('Keanu Reeves', 'Sci-Fi', 3),
-                ('Carrie-Anne Moss', 'Sci-Fi', 2),
-                ('Laurence Fishburne', 'Sci-Fi', 3),
-                ('Keanu Reeves', 'Action', 4),
-                ('Will Smith', 'Action', 5)
-            ) AS t(actor, genre, movies_count);
-            
-         */
-        final Stream<RowResult> rowResultStream = executeUpdate(urlOrKey,
-                createTable.get(), config
-                , log, params.toArray(new Object[params.size()]));
-        final RowResult rowResult = rowResultStream.findFirst().get();
-
-        final Stream<RowResult> insertResStream = executeUpdate(urlOrKey, queryInsert.get(), config, log, params.toArray(new Object[params.size()]));
-        final RowResult insertResult = insertResStream.findFirst().get();
+        // Insert data
+        executeUpdate(urlOrKey, queryInsert.get(), config, log, connection, params.toArray(new Object[params.size()]));
         // TODO: documentare che la query SQL deve avere colonne consistenti con la query neo4j
 
         // TODO step 2: fare dei test in cui passo una query che interroga la tabella temporanea
-        /*
-        SELECT
-    actor,
-    genre,
-    movies_count,
-    RANK() OVER (PARTITION BY genre ORDER BY movies_count DESC) AS rank
-        FROM temp_data
-        ORDER BY genre, rank;
-         */
-
-        /* ad esempio
-        WITH ranked_data AS (
-            SELECT 
-                category_column, 
-                pivot_column, 
-                value_column,
-                ROW_NUMBER() OVER (PARTITION BY category_column ORDER BY value_column DESC) AS rank
-            FROM neo4j_data
-            )
-         */
-        
-        // todo - altri test con query sql, tipo questo
-        /*
-        SELECT 
-            actor,
-            genre,
-            movies_count,
-            RANK() OVER (PARTITION BY genre ORDER BY movies_count DESC) AS rank
-        FROM movies_data;
-         */
-        
-        /*
-        
-         */
-
-        // TODO  step 3: return result
         try {
-            return executeQuery(urlOrKey, sqlQuery, config, log, params.toArray(new Object[params.size()]));
+            return executeQuery(urlOrKey, sqlQuery, config, log, connection, params.toArray(new Object[params.size()]));
         } catch (Exception e) {
             throw new RuntimeException(String.format("Make sure the SQL is consistent with Cypher query which has columns: %s", columns.get()));
         }
     }
 
-    private String mapSqlType(Object value) {
-        if (value instanceof Number) return "INTEGER";
-        else return "VARCHAR";
+    private String mapSqlType(Provider provider, Object value) {
+        return switch (provider) {
+            case MYSQL, POSTGRES -> {
+                if (value instanceof Number) yield "INTEGER";
+                else yield "VARCHAR(1000)";
+            }
+            default -> {
+                if (value instanceof Number) yield "INTEGER";
+                else yield "VARCHAR";
+            }
+        };
     }
 
     public String mapToString(Map<String, ?> map) {

--- a/extended/src/main/java/apoc/load/Jdbc.java
+++ b/extended/src/main/java/apoc/load/Jdbc.java
@@ -65,10 +65,10 @@ public class Jdbc {
     public Stream<RowResult> jdbc(@Name("jdbc") String urlOrKey, @Name("tableOrSql") String tableOrSelect, @Name
             (value = "params", defaultValue = "[]") List<Object> params, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
         params = params != null ? params : Collections.emptyList();
-        return executeQuery(urlOrKey, tableOrSelect, config, params.toArray(new Object[params.size()]));
+        return executeQuery(urlOrKey, tableOrSelect, config, log, params.toArray(new Object[params.size()]));
     }
 
-    private Stream<RowResult> executeQuery(String urlOrKey, String tableOrSelect, Map<String, Object> config, Object... params) {
+    public static Stream<RowResult> executeQuery(String urlOrKey, String tableOrSelect, Map<String, Object> config, Log log, Object... params) {
         LoadJdbcConfig loadJdbcConfig = new LoadJdbcConfig(config);
         String url = getUrlOrKey(urlOrKey);
         String query = getSqlOrKey(tableOrSelect);

--- a/extended/src/main/java/apoc/load/Jdbc.java
+++ b/extended/src/main/java/apoc/load/Jdbc.java
@@ -103,6 +103,41 @@ public class Jdbc {
         }
     }
 
+    public static Stream<RowResult> executeQuery(String urlOrKey, String tableOrSelect, Map<String, Object> config, Log log, Connection conn, Object... params) {
+        LoadJdbcConfig loadJdbcConfig = new LoadJdbcConfig(config);
+        String url = getUrlOrKey(urlOrKey);
+        String query = getSqlOrKey(tableOrSelect);
+        try {
+            Connection connection = conn != null ? conn : (Connection) getConnection(url, loadJdbcConfig, Connection.class);
+            // see https://jdbc.postgresql.org/documentation/91/query.html#query-with-cursors
+            connection.setAutoCommit(loadJdbcConfig.isAutoCommit());
+            try {
+                PreparedStatement stmt = connection.prepareStatement(query,ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+                stmt.setFetchSize(loadJdbcConfig.getFetchSize().intValue());
+                try {
+                    for (int i = 0; i < params.length; i++) stmt.setObject(i + 1, params[i]);
+                    ResultSet rs = stmt.executeQuery();
+                    Iterator<Map<String, Object>> supplier = new ResultSetIterator(log, rs, true, loadJdbcConfig);
+                    Spliterator<Map<String, Object>> spliterator = Spliterators.spliteratorUnknownSize(supplier, Spliterator.ORDERED);
+                    return StreamSupport.stream(spliterator, false)
+                            .map(RowResult::new)
+                            .onClose(() -> closeIt(log, stmt, connection));
+                } catch (Exception sqle) {
+                    closeIt(log, stmt);
+                    throw sqle;
+                }
+            } catch(Exception sqle) {
+                closeIt(log, connection);
+                throw sqle;
+            }
+        } catch (Exception e) {
+            log.error(String.format("Cannot execute SQL statement `%s`.%nError:%n%s", query, e.getMessage()),e);
+            String errorMessage = "Cannot execute SQL statement `%s`.%nError:%n%s";
+            if(e.getMessage().contains("No suitable driver")) errorMessage="Cannot execute SQL statement `%s`.%nError:%n%s%n%s";
+            throw new RuntimeException(String.format(errorMessage, query, e.getMessage(), "Please download and copy the JDBC driver into $NEO4J_HOME/plugins,more details at https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_load_jdbc_resources"), e);
+        }
+    }
+
     @Procedure(mode = Mode.DBMS)
     @Description("apoc.load.jdbcUpdate('key or url','statement',[params],config) YIELD row - update relational database, from a SQL statement with optional parameters")
     public Stream<RowResult> jdbcUpdate(@Name("jdbc") String urlOrKey, @Name("query") String query, @Name(value = "params", defaultValue = "[]") List<Object> params,  @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
@@ -122,6 +157,37 @@ public class Jdbc {
                     for (int i = 0; i < params.length; i++) stmt.setObject(i + 1, params[i]);
                     int updateCount = stmt.executeUpdate();
                     closeIt(log, stmt, connection);
+                    Map<String, Object> result = MapUtil.map("count", updateCount);
+                    return Stream.of(result)
+                            .map(RowResult::new);
+                } catch(Exception sqle) {
+                    closeIt(log,stmt);
+                    throw sqle;
+                }
+            } catch(Exception sqle) {
+                closeIt(log,connection);
+                throw sqle;
+            }
+        } catch (Exception e) {
+            log.error(String.format("Cannot execute SQL statement `%s`.%nError:%n%s", query, e.getMessage()),e);
+            String errorMessage = "Cannot execute SQL statement `%s`.%nError:%n%s";
+            if(e.getMessage().contains("No suitable driver")) errorMessage="Cannot execute SQL statement `%s`.%nError:%n%s%n%s";
+            throw new RuntimeException(String.format(errorMessage, query, e.getMessage(), "Please download and copy the JDBC driver into $NEO4J_HOME/plugins,more details at https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_load_jdbc_resources"), e);
+        }
+    }
+
+    public static Stream<RowResult> executeUpdate(String urlOrKey, String query, Map<String, Object> config, Log log, Connection conn, Object...params) {
+        String url = getUrlOrKey(urlOrKey);
+        LoadJdbcConfig jdbcConfig = new LoadJdbcConfig(config);
+        try {
+            Connection connection = conn != null ? conn : (Connection) getConnection(url,jdbcConfig, Connection.class);
+            try {
+                PreparedStatement stmt = connection.prepareStatement(query,ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+                stmt.setFetchSize(5000);
+                try {
+                    for (int i = 0; i < params.length; i++) stmt.setObject(i + 1, params[i]);
+                    int updateCount = stmt.executeUpdate();
+                    if (conn == null) closeIt(log, stmt, connection);
                     Map<String, Object> result = MapUtil.map("count", updateCount);
                     return Stream.of(result)
                             .map(RowResult::new);

--- a/extended/src/main/java/apoc/load/util/JdbcUtil.java
+++ b/extended/src/main/java/apoc/load/util/JdbcUtil.java
@@ -28,8 +28,14 @@ public class JdbcUtil {
         if(config.hasCredentials()) {
             return createConnection(jdbcUrl, config.getCredentials().getUser(), config.getCredentials().getPassword(), classType);
         } else {
-            URI uri = new URI(jdbcUrl.substring("jdbc:".length()));
-            String userInfo = uri.getUserInfo();
+            String userInfo = null;
+            try {
+                URI uri = new URI(jdbcUrl.substring("jdbc:".length()));
+                userInfo = uri.getUserInfo();
+            } catch (Exception e) {
+                // with DuckDB we can pass a jdbc url like "jdbc:duckdb:"
+                // this will fail executing new URI(..) due to `java.net.URISyntaxException: Expected scheme-specific part at index 7: duckdb:`
+            }
             if (userInfo != null) {
                 String cleanUrl = jdbcUrl.substring(0, jdbcUrl.indexOf("://") + 3) + jdbcUrl.substring(jdbcUrl.indexOf("@") + 1);
                 String[] user = userInfo.split(":");

--- a/extended/src/test/java/apoc/load/AbstractJdbcTest.java
+++ b/extended/src/test/java/apoc/load/AbstractJdbcTest.java
@@ -16,6 +16,8 @@ public abstract class AbstractJdbcTest {
 
     protected static java.sql.Time time = java.sql.Time.valueOf("15:37:00");
 
+    protected static final String MOVIES_CYPHER_FILE = "movies-analytics.cypher";
+
     public void assertResult(Map<String, Object> row) {
         Map<String, Object> expected = Util.map("NAME", "John", "SURNAME", null, "HIRE_DATE", hireDate.toLocalDate(), "EFFECTIVE_FROM_DATE",
                 effectiveFromDate.toLocalDateTime(), "TEST_TIME", time.toLocalTime(), "NULL_DATE", null);

--- a/extended/src/test/java/apoc/load/AnalyticsTest.java
+++ b/extended/src/test/java/apoc/load/AnalyticsTest.java
@@ -1,0 +1,8 @@
+package apoc.load;
+
+public class AnalyticsTest {
+    
+    // TODO - METTERE I TEST QUI
+    
+    // se necessario, farne di più, tipo AnalyticsMySQLTest etc...
+}

--- a/extended/src/test/java/apoc/load/AnalyticsTest.java
+++ b/extended/src/test/java/apoc/load/AnalyticsTest.java
@@ -1,8 +1,0 @@
-package apoc.load;
-
-public class AnalyticsTest {
-    
-    // TODO - METTERE I TEST QUI
-    
-    // se necessario, farne di più, tipo AnalyticsMySQLTest etc...
-}

--- a/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
+++ b/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
@@ -1,0 +1,378 @@
+package apoc.load;
+
+import apoc.periodic.Periodic;
+import apoc.util.MapUtil;
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import apoc.util.collection.Iterators;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.lang.reflect.InvocationTargetException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Types;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.UUID;
+
+import static apoc.ApocConfig.apocConfig;
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
+import static org.junit.Assert.assertEquals;
+
+public class DuckDBJdbcTest extends AbstractJdbcTest {
+
+    /*
+    TODO : scrivere sulla PR
+    When using the jdbc:duckdb: URL alone, an in-memory database is created. 
+    Note that for an in-memory database no data is persisted to disk (i.e., all data is lost when you exit the Java program). 
+    If you would like to access or create a persistent database, append its file name after the path. For example, if your database is stored in /tmp/my_database, use the JDBC URL jdbc:duckdb:/tmp/my_database to create a connection to it.
+     */
+    
+    
+    /*
+    PreparedStatement ps = conn.prepareStatement("CREATE TEMP TABLE movies AS SELECT * FROM rs");
+    ps.setObject(1, map("a", 1, "b", 2));
+    ps.executeQuery();
+     */
+    
+    public String JDBC_DUCKDB = null;
+    
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+    private Connection conn;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        // TODO - scrivere sulla PR: se mettiamo lo stesso JDBC url per tutti i test, flakily un test a caso rimane in pending senza apparente motivo 
+        //  tried also with TemporaryFolder storeDir but it fails with error: `IO Error: Could not read from file "/var/folders/kn/v9jyxl9s67z5qzf_mc8d62sm0000gp/T/junit6152729252456113118/junit894048343433219285": Is a directory`
+        //  despite here https://duckdb.org/docs/api/java#installation, defining a folder to create an embedded seems to be possible
+        JDBC_DUCKDB = "jdbc:duckdb:" + temporaryFolder.newFolder() + "/testDB";// UUID.randomUUID();
+        apocConfig().setProperty("apoc.jdbc.duckdb.url", JDBC_DUCKDB);
+        apocConfig().setProperty("apoc.jdbc.test.sql","SELECT * FROM PERSON");
+        apocConfig().setProperty("apoc.jdbc.testparams.sql","SELECT * FROM PERSON WHERE NAME = ?");
+        TestUtil.registerProcedure(db, Jdbc.class, Periodic.class);
+        
+        conn = DriverManager.getConnection(JDBC_DUCKDB);
+        createPersonTableAndData();
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        conn.close();
+//        try {
+//            DriverManager.getConnection(JDBC_DUCKDB);
+//        } catch (SQLException e) {
+//            // DerbyDB shutdown always raise a SQLException, see: http://db.apache.org/derby/docs/10.14/devguide/tdevdvlp20349.html
+//            if (((e.getErrorCode() == 45000)
+//                    && ("08006".equals(e.getSQLState())))) {
+//                // Note that for single database shutdown, the expected
+//                // SQL state is "08006", and the error code is 45000.
+//            } else {
+//                throw e;
+//            }
+//        }
+//        System.clearProperty("derby.connection.requireAuthentication");
+//        System.clearProperty("derby.user.apoc");
+    }
+
+    /*
+    TODO
+    conn.createStatement().execute("""
+        CREATE TEMPORARY TABLE movies_data AS 
+SELECT * FROM 
+(VALUES
+    ('Keanu Reeves', 'Sci-Fi', 3),
+    ('Carrie-Anne Moss', 'Sci-Fi', 2),
+    ('Laurence Fishburne', 'Sci-Fi', 3),
+    ('Keanu Reeves', 'Action', 4),
+    ('Will Smith', 'Action', 5)
+) AS t(actor, genre, movies_count);
+
+        """);
+//ps.setObject(1, map("a", 1, "b", 2));
+ps.executeQuery();
+//conn.createStatement().executeQuery("CREATE TEMPORARY TABLE movies AS SELECT * FROM ?", map())
+     */
+
+    // todo - this is the test of issue 3610
+    @Test
+    public void testLoadJdbcAnalytics() {
+        // -- create temporary table
+        System.out.println("DuckDBJdbcTest.testLoadJdbcAnalytics");
+        
+        // -- query with temporary table
+        System.out.println("DuckDBJdbcTest.testLoadJdbcAnalytics");
+    }
+    
+    // TODO:
+        // 1: create temp table
+        // 2: rank() function by default, otherwise other, configurable?
+            // fare leva sulle apoc.db che creano dei csv???
+            // forse no, però potrei fare export e poi load csv???
+        // 3: config: default DUCKDB
+
+    /*
+    Temporary Tables
+    Temporary tables can be created using the CREATE TEMP TABLE or the CREATE TEMPORARY TABLE statement (see diagram below). Temporary tables are session scoped (similar to PostgreSQL for example), meaning that only the specific connection that created them can access them, and once the connection to DuckDB is closed they will be automatically dropped. Temporary tables reside in memory rather than on disk (even when connecting to a persistent DuckDB), but if the temp_directory configuration is set when connecting or with a SET command, data will be spilled to disk if memory becomes constrained.
+    
+    Create a temporary table from a CSV file (automatically detecting column names and types):
+    
+    CREATE TEMP TABLE t1 AS
+        SELECT *
+        FROM read_csv('path/file.csv');
+    
+    Allow temporary tables to off-load excess memory to disk:
+    
+    SET temp_directory = '/path/to/directory/';
+    
+    Temporary tables are part of the temp.main schema. While discouraged, their names can overlap with the names of the regular database tables. In these cases, use their fully qualified name, e.g., temp.main.t1, for disambiguation.
+     */
+
+
+    @Test
+    public void testLoadJdbc() {
+        testCall(db, "CALL apoc.load.jdbc($url,'PERSON')",
+                map("url", JDBC_DUCKDB),
+                this::assertResult);
+    }
+
+    @Test
+    public void testLoadJdbcWithFetchSize() {
+        testCall(db, "CALL apoc.load.jdbc($url,'PERSON', null, {fetchSize: 100})",
+                map("url", JDBC_DUCKDB),
+                this::assertResult);
+    }
+
+    @Test
+    public void testLoadJdbcSelect() {
+        testCall(db, "CALL apoc.load.jdbc($url,'SELECT * FROM PERSON')",
+                map("url", JDBC_DUCKDB),
+                this::assertResult);
+    }
+    
+    @Test
+    public void testLoadJdbcSelectColumnNames() {
+        Map<String, Object> expected = map("NAME", "John",
+                "DATE", AbstractJdbcTest.hireDate.toLocalDate());
+        testCall(db, "CALL apoc.load.jdbc($url,'SELECT NAME, HIRE_DATE AS DATE FROM PERSON')",
+                map("url", JDBC_DUCKDB),
+                (row) -> assertEquals(expected, row.get("row")));
+    }
+
+    /*
+    conn.createStatement().ex("""
+        CREATE TEMPORARY TABLE movies_data AS 
+        SELECT * FROM 
+        (VALUES
+            ('Keanu Reeves', 'Sci-Fi', 3),
+            ('Carrie-Anne Moss', 'Sci-Fi', 2),
+            ('Laurence Fishburne', 'Sci-Fi', 3),
+            ('Keanu Reeves', 'Action', 4),
+            ('Will Smith', 'Action', 5)
+        ) AS t(actor, genre, movies_count);
+
+        """);
+     */
+    
+    
+    @Test
+    public void testLoadJdbcParams() {
+        testCall(db, "CALL apoc.load.jdbc($url,'SELECT * FROM PERSON WHERE NAME = ?',['John'])", //  YIELD row RETURN row
+                map("url", JDBC_DUCKDB),
+                this::assertResult);
+    }
+
+    @Test
+    public void testLoadJdbcParamsWithConfigLocalDateTime() {
+        testCall(db, "CALL apoc.load.jdbc($url,'SELECT * FROM PERSON WHERE NAME = ?',['John'])",
+                map("url", JDBC_DUCKDB),
+                this::assertResult);
+
+        ZoneId asiaTokio = ZoneId.of("Asia/Tokyo");
+
+        testCall(db, "CALL apoc.load.jdbc($url,'SELECT * FROM PERSON WHERE NAME = ?',['John'], $config)",
+                map("url", JDBC_DUCKDB,
+                        "config", map("timezone", asiaTokio.toString())),
+                (row) -> {
+                    Map<String, Object> expected = MapUtil.map("NAME", "John", "SURNAME", null,
+                            "HIRE_DATE", AbstractJdbcTest.hireDate.toLocalDate(),
+                            "EFFECTIVE_FROM_DATE", AbstractJdbcTest.effectiveFromDate.toInstant().atZone(asiaTokio).toOffsetDateTime().toZonedDateTime(), // todo investigate why by only changing the procedure mode returned class type changes
+                            "TEST_TIME", AbstractJdbcTest.time.toLocalTime(),
+                            "NULL_DATE", null);
+                    Map<String, Object> rowColumn = (Map<String, Object>) row.get("row");
+
+                    expected.keySet().forEach( k -> {
+                        assertEquals(expected.get(k), rowColumn.get(k));
+                    });
+                    assertEquals(expected, rowColumn);
+                }
+
+        );
+    }
+
+    @Test
+    public void testLoadJdbcParamsWithWrongTimezoneValue() {
+        thrown.expect(QueryExecutionException.class);
+        thrown.expectMessage("Failed to invoke procedure `apoc.load.jdbc`: Caused by: java.lang.IllegalArgumentException: The timezone field contains an error: Unknown time-zone ID: Italy/Pescara");
+        TestUtil.singleResultFirstColumn(db,"CALL apoc.load.jdbc('jdbc:duckdb:testDB','SELECT * FROM PERSON WHERE NAME = ?',['John'], {timezone: $timezone})",
+                map("timezone", "Italy/Pescara"));
+    }
+
+    @Test
+    public void testLoadJdbcKey() {
+        testCall(db, "CALL apoc.load.jdbc('duckdb','PERSON')",
+                this::assertResult);
+    }
+
+    @Test
+    public void testLoadJdbcSqlAlias() {
+        testCall(db, "CALL apoc.load.jdbc('duckdb','test')",
+                this::assertResult);
+    }
+
+    @Test
+    public void testLoadJdbcSqlAliasParams() {
+        testCall(db, "CALL apoc.load.jdbc($url,'testparams',['John'])", //  YIELD row RETURN row
+                map("url", JDBC_DUCKDB),
+                this::assertResult);
+    }
+
+    @Test
+    public void testLoadJdbcError() {
+        thrown.expect(QueryExecutionException.class);
+        thrown.expectMessage("Invalid input");
+        db.executeTransactionally("CALL apoc.load.jdbc(''jdbc:duckdb:testDB'','PERSON2')");
+    }
+
+    @Test
+    public void testLoadJdbcProcessingError() {
+        thrown.expect(QueryExecutionException.class);
+        thrown.expectMessage("Invalid input");
+        db.executeTransactionally("CALL apoc.load.jdbc(''jdbc:duckdb:testDB'','PERSON') YIELD row where row.name / 2 = 5 RETURN row");
+    }
+
+    @Test
+    public void testLoadJdbcUpdate() {
+        testCall(db, "CALL apoc.load.jdbcUpdate($url,'UPDATE PERSON SET SURNAME = ? WHERE NAME = ?', ['DOE', 'John'])",
+                map("url", JDBC_DUCKDB),
+                (row) -> assertEquals(Util.map("count", 1 ), row.get("row")));
+    }
+
+    @Test
+    public void testLoadJdbcUpdateParams() {
+        testCall(db, "CALL apoc.load.jdbcUpdate($url,'UPDATE PERSON SET SURNAME = ? WHERE NAME = ?',['John','John'])",
+                map("url", JDBC_DUCKDB),
+                (row) -> assertEquals(Util.map("count", 1 ), row.get("row")));
+    }
+
+    @Test
+    public void testWithPeriodic() {
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute("delete from person");
+            stmt.execute("select count(*) as size from person");
+            stmt.getResultSet().next();
+            int size = stmt.getResultSet().getInt("size");
+            assertEquals(0 , size);
+        } catch (Exception e) { }
+
+        db.executeTransactionally("UNWIND range(1, 100) AS id CREATE (p:Person{id: id, name: 'Name ' + id, surname: 'Surname ' + id})");
+        String query = "CALL apoc.periodic.iterate(\n" +
+                "'MATCH (p:Person) RETURN p.name AS name, p.surname AS surname limit 1',\n" +
+                "\"CALL apoc.load.jdbcUpdate($url, 'INSERT INTO PERSON(NAME, SURNAME) VALUES(?, ?)', [name, surname]) YIELD row RETURN 'DONE'\",\n" +
+                "{batchSize: 20, iterateList: false, params: {url: $url}, parallel: true}\n" +
+                ")\n" +
+                "YIELD committedOperations, failedOperations, failedBatches, errorMessages\n" +
+                "RETURN *";
+        testCall(db,
+                query,
+                map("url", "jdbc:duckdb:testDB"),
+                (row) -> {
+                    try (Statement stmt = conn.createStatement()) {
+                        stmt.execute("select count(*) as size from person");
+                        stmt.getResultSet().next();
+                        int size = stmt.getResultSet().getInt("size");
+                        assertEquals(1, size);
+                    } catch (Exception e) { }
+                });
+    }
+
+    @Test
+    public void testIterateJDBC() {
+        final String jdbc = "CALL apoc.load.jdbc($url, 'PERSON',[]) YIELD row RETURN row";
+        final String create = "CREATE (p:Person) SET p += row";
+        testResult(db, "CALL apoc.periodic.iterate($jdbcQuery, $createQuery, {params: $params})",
+                Util.map("params", Util.map("url", JDBC_DUCKDB), "jdbcQuery", jdbc, "createQuery", create), result -> {
+                    Map<String, Object> row = Iterators.single(result);
+                    assertEquals(1L, row.get("batches"));
+                    assertEquals(1L, row.get("total"));
+                });
+
+        testCall(db,
+                "MATCH (p:Person) return count(p) as count",
+                row -> assertEquals(1L, row.get("count"))
+        );
+    }
+
+    private void createPersonTableAndData() throws SQLException {
+        try { conn.createStatement().execute("DROP TABLE PERSON"); } catch (SQLException se) {/*ignore*/}
+        conn.createStatement().execute("CREATE TABLE PERSON (NAME varchar(50), SURNAME varchar(50), HIRE_DATE DATE, EFFECTIVE_FROM_DATE TIMESTAMP, TEST_TIME TIME, NULL_DATE DATE)");
+        PreparedStatement ps = conn.prepareStatement("INSERT INTO PERSON values(?,null,?,?,?,?)");
+        ps.setString(1, "John");
+        ps.setDate(2, AbstractJdbcTest.hireDate);
+        ps.setTimestamp(3, AbstractJdbcTest.effectiveFromDate);
+        
+        
+        // TODO workaround, DuckDB is shifted 1 hour later
+        //      VEDERE SE c'è un modo più carino, invece di passare un valore manuale 1 ora indietro a AbstractJdbcTest.time
+        //      altrimenti va bene così
+        
+        // since currenty neither         ps.setTime(4, AbstractJdbcTest.time, Calendar.getInstance(TimeZone.getTimeZone("UTC")));
+        // or  ps.setObject(1, localTime); is possible
+        ps.setTime(4, java.sql.Time.valueOf("16:37:00"));
+//        ps.setObject(4, AbstractJdbcTest.time.toLocalTime());//, Calendar.getInstance(TimeZone.getTimeZone("UTC")));
+        ps.setNull(5, Types.DATE);
+        int rows = ps.executeUpdate();
+        assertEquals(1, rows);
+        ResultSet rs = conn.createStatement().executeQuery("SELECT NAME, HIRE_DATE, EFFECTIVE_FROM_DATE, TEST_TIME FROM PERSON");
+        assertEquals(true, rs.next());
+        assertEquals("John", rs.getString("NAME"));
+        Assert.assertEquals(AbstractJdbcTest.hireDate.toLocalDate(), rs.getDate("HIRE_DATE").toLocalDate());
+        Assert.assertEquals(AbstractJdbcTest.effectiveFromDate, rs.getTimestamp("EFFECTIVE_FROM_DATE"));
+
+        // workaround, here the hour is 15:37
+        Assert.assertEquals(AbstractJdbcTest.time, rs.getTime("TEST_TIME"));
+        assertEquals(false, rs.next());
+        rs.close();
+    }
+
+}

--- a/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
+++ b/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
@@ -61,7 +61,7 @@ public class DuckDBJdbcTest extends AbstractJdbcTest {
         conn = DriverManager.getConnection(JDBC_DUCKDB);
         createPersonTableAndData();
 
-        String movies = Util.readResourceFile("movies-analytics.cypher");
+        String movies = Util.readResourceFile(MOVIES_CYPHER_FILE);
         try (Transaction tx = db.beginTx()) {
             tx.execute(movies);
             tx.commit();

--- a/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
+++ b/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
@@ -6,37 +6,26 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestName;
-import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
-import java.lang.reflect.InvocationTargetException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Time;
 import java.sql.Types;
 import java.time.ZoneId;
-import java.util.Calendar;
 import java.util.Map;
-import java.util.TimeZone;
-import java.util.UUID;
 
 import static apoc.ApocConfig.apocConfig;
 import static apoc.util.MapUtil.map;
@@ -44,23 +33,10 @@ import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 public class DuckDBJdbcTest extends AbstractJdbcTest {
 
-    /*
-    TODO : scrivere sulla PR
-    When using the jdbc:duckdb: URL alone, an in-memory database is created. 
-    Note that for an in-memory database no data is persisted to disk (i.e., all data is lost when you exit the Java program). 
-    If you would like to access or create a persistent database, append its file name after the path. For example, if your database is stored in /tmp/my_database, use the JDBC URL jdbc:duckdb:/tmp/my_database to create a connection to it.
-     */
-    
-    
-    /*
-    PreparedStatement ps = conn.prepareStatement("CREATE TEMP TABLE movies AS SELECT * FROM rs");
-    ps.setObject(1, map("a", 1, "b", 2));
-    ps.executeQuery();
-     */
-    
     public String JDBC_DUCKDB = null;
     
     @Rule
@@ -76,9 +52,6 @@ public class DuckDBJdbcTest extends AbstractJdbcTest {
 
     @Before
     public void setUp() throws Exception {
-        // TODO - scrivere sulla PR: se mettiamo lo stesso JDBC url per tutti i test, flakily un test a caso rimane in pending senza apparente motivo 
-        //  tried also with TemporaryFolder storeDir but it fails with error: `IO Error: Could not read from file "/var/folders/kn/v9jyxl9s67z5qzf_mc8d62sm0000gp/T/junit6152729252456113118/junit894048343433219285": Is a directory`
-        //  despite here https://duckdb.org/docs/api/java#installation, defining a folder to create an embedded seems to be possible
         JDBC_DUCKDB = "jdbc:duckdb:" + temporaryFolder.newFolder() + "/testDB";// UUID.randomUUID();
         apocConfig().setProperty("apoc.jdbc.duckdb.url", JDBC_DUCKDB);
         apocConfig().setProperty("apoc.jdbc.test.sql","SELECT * FROM PERSON");
@@ -98,56 +71,22 @@ public class DuckDBJdbcTest extends AbstractJdbcTest {
     @After
     public void tearDown() throws SQLException {
         conn.close();
-//        try {
-//            DriverManager.getConnection(JDBC_DUCKDB);
-//        } catch (SQLException e) {
-//            // DerbyDB shutdown always raise a SQLException, see: http://db.apache.org/derby/docs/10.14/devguide/tdevdvlp20349.html
-//            if (((e.getErrorCode() == 45000)
-//                    && ("08006".equals(e.getSQLState())))) {
-//                // Note that for single database shutdown, the expected
-//                // SQL state is "08006", and the error code is 45000.
-//            } else {
-//                throw e;
-//            }
-//        }
-//        System.clearProperty("derby.connection.requireAuthentication");
-//        System.clearProperty("derby.user.apoc");
     }
 
-    /*
-    TODO
-    conn.createStatement().execute("""
-        CREATE TEMPORARY TABLE movies_data AS 
-SELECT * FROM 
-(VALUES
-    ('Keanu Reeves', 'Sci-Fi', 3),
-    ('Carrie-Anne Moss', 'Sci-Fi', 2),
-    ('Laurence Fishburne', 'Sci-Fi', 3),
-    ('Keanu Reeves', 'Action', 4),
-    ('Will Smith', 'Action', 5)
-) AS t(actor, genre, movies_count);
-
-        """);
-//ps.setObject(1, map("a", 1, "b", 2));
-ps.executeQuery();
-//conn.createStatement().executeQuery("CREATE TEMPORARY TABLE movies AS SELECT * FROM ?", map())
-     */
-
-    // todo - this is the test of issue 3610
     @Test
     public void testLoadJdbcAnalytics() {
         String cypher = "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline";
 
         String sql = """
-        SELECT
-        title,
-        released,
-        language,
-        tagline,
-        RANK() OVER (PARTITION BY language ORDER BY released DESC) AS rank
-        FROM temp_table
-        ORDER BY rank, title, tagline;
-        """;
+            SELECT
+            title,
+            released,
+            language,
+            tagline,
+            RANK() OVER (PARTITION BY language ORDER BY released DESC) AS rank
+            FROM temp_table
+            ORDER BY rank, title, tagline;
+            """;
         testResult(db, "CALL apoc.load.jdbc.analytics($queryCypher, $url, $sql)",
                 map(
                         "queryCypher", cypher,
@@ -179,34 +118,102 @@ ps.executeQuery();
                     result = (Map) row.get("row");
                     rank = (long) result.get("rank");
                     assertEquals(3, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(4, rank);
+
                     assertFalse(r.hasNext());
                 });
     }
-    
-    // TODO:
-        // 1: create temp table
-        // 2: rank() function by default, otherwise other, configurable?
-            // fare leva sulle apoc.db che creano dei csv???
-            // forse no, però potrei fare export e poi load csv???
-        // 3: config: default DUCKDB
 
-    /*
-    Temporary Tables
-    Temporary tables can be created using the CREATE TEMP TABLE or the CREATE TEMPORARY TABLE statement (see diagram below). Temporary tables are session scoped (similar to PostgreSQL for example), meaning that only the specific connection that created them can access them, and once the connection to DuckDB is closed they will be automatically dropped. Temporary tables reside in memory rather than on disk (even when connecting to a persistent DuckDB), but if the temp_directory configuration is set when connecting or with a SET command, data will be spilled to disk if memory becomes constrained.
-    
-    Create a temporary table from a CSV file (automatically detecting column names and types):
-    
-    CREATE TEMP TABLE t1 AS
-        SELECT *
-        FROM read_csv('path/file.csv');
-    
-    Allow temporary tables to off-load excess memory to disk:
-    
-    SET temp_directory = '/path/to/directory/';
-    
-    Temporary tables are part of the temp.main schema. While discouraged, their names can overlap with the names of the regular database tables. In these cases, use their fully qualified name, e.g., temp.main.t1, for disambiguation.
-     */
+    @Test
+    public void testLoadJdbcAnalyticsDuckDBWindow() {
+        final String ROW = "row";
+        final String IT = "it";
+        final String EN = "en";
+        final String RELEASED = "released";
 
+        String cypher = "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline, n.qty AS qty";
+
+        String sql = """
+                WITH ranked_data AS (
+                    SELECT
+                    title,
+                    released,
+                    language,
+                    tagline,
+                    qty,
+                    ROW_NUMBER() OVER (PARTITION BY language ORDER BY released DESC) AS rank
+                    FROM temp_table
+                    ORDER BY rank, title, tagline
+                )
+                
+                SELECT *
+                FROM ranked_data
+                PIVOT (
+                    sum(qty)
+                    FOR 
+                        language IN ('en', 'it')
+                    GROUP BY released
+                )
+                """;
+
+        testResult(db, "CALL apoc.load.jdbc.analytics($queryCypher, $url, $sql)",
+                map(
+                        "queryCypher", cypher,
+                        "sql", sql,
+                        "url", JDBC_DUCKDB
+                ),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    var result = (Map) row.get(ROW);
+                    var released = (int) result.get(RELEASED);
+                    var it = (String) result.get(IT);
+                    var en = (String) result.get(EN);
+                    assertEquals(1986, released);
+                    assertEquals("12", it);
+                    assertNull(en);
+
+                    row = r.next();
+                    result = (Map) row.get(ROW);
+                    released = (int) result.get(RELEASED);
+                    it = (String) result.get(IT);
+                    en = (String) result.get(EN);
+                    assertEquals(1992, released);
+                    assertEquals("7", it);
+                    assertNull(en);
+
+                    row = r.next();
+                    result = (Map) row.get(ROW);
+                    released = (int) result.get(RELEASED);
+                    it = (String) result.get(IT);
+                    en = (String) result.get(EN);
+                    assertEquals(1997, released);
+                    assertEquals("3", en);
+                    assertNull(it);
+
+                    row = r.next();
+                    result = (Map) row.get(ROW);
+                    released = (int) result.get(RELEASED);
+                    it = (String) result.get(IT);
+                    en = (String) result.get(EN);
+                    assertEquals(1999, released);
+                    assertEquals("5", en);
+                    assertNull(it);
+
+                    row = r.next();
+                    result = (Map) row.get(ROW);
+                    released = (int) result.get(RELEASED);
+                    it = (String) result.get(IT);
+                    en = (String) result.get(EN);
+                    assertEquals(2003, released);
+                    assertEquals("17", en);
+                    assertNull(it);
+                    assertFalse(r.hasNext());
+                });
+    }
 
     @Test
     public void testLoadJdbc() {
@@ -238,22 +245,6 @@ ps.executeQuery();
                 (row) -> assertEquals(expected, row.get("row")));
     }
 
-    /*
-    conn.createStatement().ex("""
-        CREATE TEMPORARY TABLE movies_data AS 
-        SELECT * FROM 
-        (VALUES
-            ('Keanu Reeves', 'Sci-Fi', 3),
-            ('Carrie-Anne Moss', 'Sci-Fi', 2),
-            ('Laurence Fishburne', 'Sci-Fi', 3),
-            ('Keanu Reeves', 'Action', 4),
-            ('Will Smith', 'Action', 5)
-        ) AS t(actor, genre, movies_count);
-
-        """);
-     */
-    
-    
     @Test
     public void testLoadJdbcParams() {
         testCall(db, "CALL apoc.load.jdbc($url,'SELECT * FROM PERSON WHERE NAME = ?',['John'])", //  YIELD row RETURN row

--- a/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
+++ b/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
@@ -17,7 +17,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
+import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -41,6 +43,7 @@ import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class DuckDBJdbcTest extends AbstractJdbcTest {
 
@@ -80,10 +83,16 @@ public class DuckDBJdbcTest extends AbstractJdbcTest {
         apocConfig().setProperty("apoc.jdbc.duckdb.url", JDBC_DUCKDB);
         apocConfig().setProperty("apoc.jdbc.test.sql","SELECT * FROM PERSON");
         apocConfig().setProperty("apoc.jdbc.testparams.sql","SELECT * FROM PERSON WHERE NAME = ?");
-        TestUtil.registerProcedure(db, Jdbc.class, Periodic.class);
+        TestUtil.registerProcedure(db, Jdbc.class, Periodic.class, Analytics.class);
         
         conn = DriverManager.getConnection(JDBC_DUCKDB);
         createPersonTableAndData();
+
+        String movies = Util.readResourceFile("movies-analytics.cypher");
+        try (Transaction tx = db.beginTx()) {
+            tx.execute(movies);
+            tx.commit();
+        }
     }
 
     @After
@@ -127,11 +136,51 @@ ps.executeQuery();
     // todo - this is the test of issue 3610
     @Test
     public void testLoadJdbcAnalytics() {
-        // -- create temporary table
-        System.out.println("DuckDBJdbcTest.testLoadJdbcAnalytics");
-        
-        // -- query with temporary table
-        System.out.println("DuckDBJdbcTest.testLoadJdbcAnalytics");
+        String cypher = "MATCH (n:Movie) RETURN n.title AS title, n.released AS released, n.language AS language, n.tagline AS tagline";
+
+        String sql = """
+        SELECT
+        title,
+        released,
+        language,
+        tagline,
+        RANK() OVER (PARTITION BY language ORDER BY released DESC) AS rank
+        FROM temp_table
+        ORDER BY rank, title, tagline;
+        """;
+        testResult(db, "CALL apoc.load.jdbc.analytics($queryCypher, $url, $sql)",
+                map(
+                        "queryCypher", cypher,
+                        "sql", sql,
+                        "url", JDBC_DUCKDB
+                ),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    var result = (Map) row.get("row");
+                    var rank = (long) result.get("rank");
+                    assertEquals(1, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(1, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(1, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(2, rank);
+
+                    row = r.next();
+                    result = (Map) row.get("row");
+                    rank = (long) result.get("rank");
+                    assertEquals(3, rank);
+                    assertFalse(r.hasNext());
+                });
     }
     
     // TODO:

--- a/extended/src/test/resources/movies-analytics.cypher
+++ b/extended/src/test/resources/movies-analytics.cypher
@@ -1,0 +1,6 @@
+CREATE (:Movie {title:'The Matrix', language: 'en', released:1999, tagline:'Welcome to the Real World', qty: 5})
+CREATE (:Movie {title:'The Matrix Reloaded', language: 'en', released:2003, tagline:'Free your mind', qty: 6})
+CREATE (:Movie {title:'The Matrix Revolutions', language: 'en', released:2003, tagline:'Everything that has a beginning has an end', qty: 11})
+CREATE (:Movie {title:"The Devil's Advocate", language: 'en', released:1997, tagline:'Evil has its winning ways', qty: 3})
+CREATE (:Movie {title:"A Few Good Men", language: 'it', released:1992, tagline:"In the heart of the nation's capital, in a courthouse of the U.S. government, one man will stop at nothing to keep his honor, and one will stop at nothing to find the truth.", qty: 7})
+CREATE (:Movie {title:"Top Gun", released:1986, language: 'it', tagline:'I feel the need, the need for speed.', qty: 12})


### PR DESCRIPTION
When using the jdbc:duckdb: URL alone, an in-memory database is created. 
    Note that for an in-memory database no data is persisted to disk (i.e., all data is lost when you exit the Java program). 
    If you would like to access or create a persistent database, append its file name after the path. For example, if your database is stored in /tmp/my_database, use the JDBC URL jdbc:duckdb:/tmp/my_database to create a connection to it.

Example: 
```java
 PreparedStatement ps = conn.prepareStatement("CREATE TEMP TABLE movies AS SELECT * FROM rs");
    ps.setObject(1, map("a", 1, "b", 2));
    ps.executeQuery();
```

- Se mettiamo lo stesso JDBC url per tutti i test, flakily un test a caso rimane in pending senza apparente motivo
- tried also with TemporaryFolder storeDir but it fails with error: `IO Error: Could not read from file "/var/folders/kn/v9jyxl9s67z5qzf_mc8d62sm0000gp/T/junit6152729252456113118/junit894048343433219285": Is a directory` despite here https://duckdb.org/docs/api/java#installation, defining a folder to create an embedded seems to be possible
- Add handling: some SQL database like Microsoft SQL Server create temp table in a different way
- abbiamo testato anche le apoc.load.jdbc* con DuckDB e fixato eventuali errori